### PR TITLE
feat(#84): isr cache revalidation and auth rate limiting

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -40,6 +40,11 @@ ADMIN_PASSWORD_HASH=
 # Generate: openssl rand -hex 32
 CRON_SECRET=
 
+# ── Rate Limiting (Upstash Redis) ─────────────────────────────────────────────
+# Connect via Vercel Marketplace → Upstash Redis, or set manually
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+
 # ── Cloudinary ─────────────────────────────────────────────────────────────────
 # Public (used by next-cloudinary CldImage on the client)
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -27,7 +27,7 @@ import { getSiteUrl } from '@web/utils/url/generateUrl'
 
 import { StyledPage } from './page.next.styles'
 
-export const revalidate = 60
+export const revalidate = 3600
 
 const dateLocales: Record<Locale, DateLocale> = { en: enUS, es }
 

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -14,6 +14,7 @@ import { getServerTranslation } from '@web/i18n/server'
 import { getCategoryTranslations } from '@web/lib/db/queries/categories'
 import { getPostByNumber, getPublishedPosts } from '@web/lib/db/queries/posts'
 import { Locale } from '@web/lib/db/schema'
+import { logger } from '@web/lib/logger'
 import { extractToc } from '@web/lib/mdx/remarkHeadings'
 import { renderMDX } from '@web/lib/mdx/renderMDX'
 import { generateArticleJsonLd } from '@web/lib/seo/generateArticleJsonLd'
@@ -61,7 +62,11 @@ export async function generateStaticParams() {
       }),
     )
     return results.flat()
-  } catch {
+  } catch (err) {
+    logger.error(
+      err,
+      'generateStaticParams failed — posts will not be pre-rendered',
+    )
     return []
   }
 }

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
@@ -27,6 +27,9 @@ jest.mock('@web/i18n/server', () => ({
   getServerTranslation: mockGetServerTranslation,
 }))
 
+const mockLoggerError = jest.fn()
+jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+
 const mockHeaders = jest.fn()
 jest.mock('next/headers', () => ({
   headers: () => mockHeaders(),
@@ -329,11 +332,16 @@ describe('[lng]/blog/[id]/[slug] - BlogPostPage', () => {
     ])
   })
 
-  it('generateStaticParams returns empty array when DB fails', async () => {
-    mockGetPublishedPosts.mockRejectedValue(new Error('no db'))
+  it('generateStaticParams returns empty array and logs error when DB fails', async () => {
+    const err = new Error('no db')
+    mockGetPublishedPosts.mockRejectedValue(err)
     const { generateStaticParams } = require('./page.next')
     const params = await generateStaticParams()
     expect(params).toEqual([])
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      err,
+      'generateStaticParams failed — posts will not be pre-rendered',
+    )
   })
 
   describe('generateMetadata', () => {

--- a/apps/web/app/[lng]/blog/[id]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/page.next.tsx
@@ -2,6 +2,8 @@ import { notFound, redirect } from 'next/navigation'
 
 import { getPostByNumber } from '@web/lib/db/queries/posts'
 
+export const revalidate = 3600
+
 interface RouteProps {
   params: Promise<{ lng: string; id: string }>
 }

--- a/apps/web/app/[lng]/blog/page.next.tsx
+++ b/apps/web/app/[lng]/blog/page.next.tsx
@@ -3,6 +3,8 @@ import { getServerTranslation } from '@web/i18n/server'
 import { Locale } from '@web/lib/db/schema'
 import { buildAlternates } from '@web/utils/metadata/inLanguage'
 
+export const revalidate = 60
+
 interface RouteProps {
   params: Promise<{ lng: Locale }>
   searchParams: Promise<{

--- a/apps/web/app/admin/login/components/LoginForm/LoginForm.spec.tsx
+++ b/apps/web/app/admin/login/components/LoginForm/LoginForm.spec.tsx
@@ -22,6 +22,7 @@ jest.mock('@web/i18n/client', () => ({
         'login.signingIn': 'Signing in…',
         'login.signIn': 'Sign in',
         'login.invalidCredentials': 'Invalid credentials',
+        'login.tooManyAttempts': 'Too many attempts, try again in 1 minute',
       }
       return translations[key] ?? key
     },
@@ -170,5 +171,28 @@ describe('LoginForm', () => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
       expect(mockNavigateTo).toHaveBeenCalledWith('/admin/posts')
     })
+  })
+
+  it('shows rate limit error on 429 response', async () => {
+    mockSignIn.mockResolvedValue({ status: 429, error: 'TooManyRequests' })
+
+    renderApp(<LoginForm />)
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'admin' },
+    })
+    fireEvent.change(
+      screen.getByLabelText(/password/i, { selector: 'input' }),
+      {
+        target: { value: 'password' },
+      },
+    )
+    fireEvent.submit(screen.getByTestId('login-form'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Too many attempts, try again in 1 minute',
+      )
+    })
+    expect(mockNavigateTo).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/app/admin/login/components/LoginForm/LoginForm.tsx
+++ b/apps/web/app/admin/login/components/LoginForm/LoginForm.tsx
@@ -38,7 +38,9 @@ export function LoginForm() {
       redirect: false,
     })
     setLoading(false)
-    if (result?.error) {
+    if (result?.status === 429) {
+      setError(t('login.tooManyAttempts'))
+    } else if (result?.error) {
       setError(t('login.invalidCredentials'))
     } else {
       navigateTo('/admin/posts')

--- a/apps/web/app/api/cron/publish/route.spec.ts
+++ b/apps/web/app/api/cron/publish/route.spec.ts
@@ -92,7 +92,8 @@ describe('GET /api/cron/publish', () => {
       { id: 'post-1', scheduledAt: new Date('2024-01-10T08:00:00Z') },
     ])
     await GET(makeRequest('Bearer test-secret-xyz'))
-    expect(mockRevalidateTag).toHaveBeenCalledWith('posts', 'default')
+    expect(mockRevalidateTag).toHaveBeenCalledWith('posts')
+    expect(mockRevalidateTag).toHaveBeenCalledWith('post-post-1')
   })
 
   it('does not call revalidateTag when no posts are published', async () => {

--- a/apps/web/app/api/cron/publish/route.ts
+++ b/apps/web/app/api/cron/publish/route.ts
@@ -26,7 +26,10 @@ export async function GET(request: NextRequest) {
   )
 
   if (scheduled.length > 0) {
-    revalidateTag('posts', 'default')
+    revalidateTag('posts')
+    for (const post of scheduled) {
+      revalidateTag(`post-${post.id}`)
+    }
   }
 
   return NextResponse.json({ published: scheduled.length })

--- a/apps/web/app/api/images/[...publicId]/route.spec.ts
+++ b/apps/web/app/api/images/[...publicId]/route.spec.ts
@@ -3,11 +3,13 @@
  */
 const mockAuth = jest.fn()
 const mockDestroyImage = jest.fn()
+const mockLoggerError = jest.fn()
 
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/cloudinary/images', () => ({
   destroyImage: mockDestroyImage,
 }))
+jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
 
 const { DELETE } = require('./route') as {
   DELETE: (
@@ -49,9 +51,10 @@ describe('DELETE /api/images/[...publicId]', () => {
     expect(mockDestroyImage).toHaveBeenCalledWith('sawl.dev - blog/photo')
   })
 
-  it('returns 500 when destroyImage throws', async () => {
+  it('returns 500 and logs error when destroyImage throws', async () => {
     mockAuth.mockResolvedValue({ user: { name: 'admin' } })
-    mockDestroyImage.mockRejectedValue(new Error('Destroy failed'))
+    const err = new Error('Destroy failed')
+    mockDestroyImage.mockRejectedValue(err)
     const response = await DELETE(
       new Request('http://localhost/api/images/sawl.dev%20-%20blog/photo', {
         method: 'DELETE',
@@ -61,6 +64,7 @@ describe('DELETE /api/images/[...publicId]', () => {
     expect(response.status).toBe(500)
     const body = (await response.json()) as { error: string }
     expect(body.error).toBe('Failed to delete image')
+    expect(mockLoggerError).toHaveBeenCalledWith(err, 'Failed to delete image')
   })
 })
 

--- a/apps/web/app/api/images/[...publicId]/route.ts
+++ b/apps/web/app/api/images/[...publicId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { auth } from '@web/lib/auth/config'
 import { destroyImage } from '@web/lib/cloudinary/images'
+import { logger } from '@web/lib/logger'
 
 export async function DELETE(
   _request: Request,
@@ -16,7 +17,8 @@ export async function DELETE(
   const publicId = segments.join('/')
   try {
     await destroyImage(publicId)
-  } catch {
+  } catch (err) {
+    logger.error(err, 'Failed to delete image')
     return NextResponse.json(
       { error: 'Failed to delete image' },
       { status: 500 },

--- a/apps/web/app/api/images/route.spec.ts
+++ b/apps/web/app/api/images/route.spec.ts
@@ -6,12 +6,14 @@ import { NextRequest } from 'next/server'
 const mockAuth = jest.fn()
 const mockListImages = jest.fn()
 const mockRenameImage = jest.fn()
+const mockLoggerError = jest.fn()
 
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/cloudinary/images', () => ({
   listImages: mockListImages,
   renameImage: mockRenameImage,
 }))
+jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
 
 const { GET, PATCH } = require('./route') as {
   GET: (request: NextRequest) => Promise<Response>
@@ -93,13 +95,15 @@ describe('GET /api/images', () => {
     expect(mockListImages).toHaveBeenCalledWith(undefined)
   })
 
-  it('returns 500 when listImages throws', async () => {
+  it('returns 500 and logs error when listImages throws', async () => {
     mockAuth.mockResolvedValue({ user: { name: 'admin' } })
-    mockListImages.mockRejectedValue(new Error('Cloudinary error'))
+    const err = new Error('Cloudinary error')
+    mockListImages.mockRejectedValue(err)
     const response = await GET(makeRequest())
     expect(response.status).toBe(500)
     const body = (await response.json()) as { error: string }
     expect(body.error).toBe('Failed to list images')
+    expect(mockLoggerError).toHaveBeenCalledWith(err, 'Failed to list images')
   })
 })
 
@@ -168,9 +172,10 @@ describe('PATCH /api/images', () => {
     )
   })
 
-  it('returns 500 when renameImage throws', async () => {
+  it('returns 500 and logs error when renameImage throws', async () => {
     mockAuth.mockResolvedValue({ user: { name: 'admin' } })
-    mockRenameImage.mockRejectedValue(new Error('Cloudinary error'))
+    const err = new Error('Cloudinary error')
+    mockRenameImage.mockRejectedValue(err)
     const response = await PATCH(
       makePatchRequest({
         publicId: 'sawl.dev - blog/photo',
@@ -180,6 +185,7 @@ describe('PATCH /api/images', () => {
     expect(response.status).toBe(500)
     const body = (await response.json()) as { error: string }
     expect(body.error).toBe('Failed to rename image')
+    expect(mockLoggerError).toHaveBeenCalledWith(err, 'Failed to rename image')
   })
 })
 

--- a/apps/web/app/api/images/route.ts
+++ b/apps/web/app/api/images/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 
 import { auth } from '@web/lib/auth/config'
 import { listImages, renameImage } from '@web/lib/cloudinary/images'
+import { logger } from '@web/lib/logger'
 
 export async function GET(request: NextRequest) {
   const session = await auth()
@@ -16,7 +17,8 @@ export async function GET(request: NextRequest) {
       { images, ...(nextCursor ? { nextCursor } : {}) },
       { status: 200 },
     )
-  } catch {
+  } catch (err) {
+    logger.error(err, 'Failed to list images')
     return NextResponse.json(
       { error: 'Failed to list images' },
       { status: 500 },
@@ -43,7 +45,8 @@ export async function PATCH(request: NextRequest) {
   try {
     const image = await renameImage(publicId, newName)
     return NextResponse.json(image, { status: 200 })
-  } catch {
+  } catch (err) {
+    logger.error(err, 'Failed to rename image')
     return NextResponse.json(
       { error: 'Failed to rename image' },
       { status: 500 },

--- a/apps/web/app/api/posts/[id]/route.spec.ts
+++ b/apps/web/app/api/posts/[id]/route.spec.ts
@@ -15,6 +15,9 @@ const mockEnsureSeries = jest.fn()
 const mockUpsertSeriesTranslation = jest.fn()
 const mockSeriesOrderExistsForSeries = jest.fn()
 
+const mockRevalidateTag = jest.fn()
+
+jest.mock('next/cache', () => ({ revalidateTag: mockRevalidateTag }))
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/db/queries/categories', () => ({
   getCategoryBySlug: mockGetCategoryBySlug,
@@ -339,6 +342,10 @@ describe('PUT /api/posts/[id]', () => {
     )
     expect(response.status).toBe(200)
     expect(mockUpdatePost).toHaveBeenCalled()
+    expect(mockRevalidateTag).toHaveBeenCalledWith('posts')
+    expect(mockRevalidateTag).toHaveBeenCalledWith(
+      'post-01JWTEST000000000000000000',
+    )
   })
 
   it('upserts translations when provided', async () => {
@@ -588,6 +595,10 @@ describe('DELETE /api/posts/[id]', () => {
     expect(mockSoftDeletePost).toHaveBeenCalledWith(
       '01JWTEST000000000000000000',
     )
+    expect(mockRevalidateTag).toHaveBeenCalledWith('posts')
+    expect(mockRevalidateTag).toHaveBeenCalledWith(
+      'post-01JWTEST000000000000000000',
+    )
   })
 
   it('hard-deletes archived post and returns 204', async () => {
@@ -605,6 +616,10 @@ describe('DELETE /api/posts/[id]', () => {
       '01JWTEST000000000000000000',
     )
     expect(mockSoftDeletePost).not.toHaveBeenCalled()
+    expect(mockRevalidateTag).toHaveBeenCalledWith('posts')
+    expect(mockRevalidateTag).toHaveBeenCalledWith(
+      'post-01JWTEST000000000000000000',
+    )
   })
 
   it('returns 422 when hard-deleting a non-archived post', async () => {

--- a/apps/web/app/api/posts/[id]/route.ts
+++ b/apps/web/app/api/posts/[id]/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -219,6 +220,8 @@ export async function PUT(
     }
   }
 
+  revalidateTag('posts')
+  revalidateTag(`post-${id}`)
   return NextResponse.json(post)
 }
 
@@ -245,6 +248,8 @@ export async function DELETE(
       )
     }
     await hardDeletePost(id)
+    revalidateTag('posts')
+    revalidateTag(`post-${id}`)
     return new NextResponse(null, { status: 204 })
   }
 
@@ -256,5 +261,7 @@ export async function DELETE(
   }
 
   await softDeletePost(id)
+  revalidateTag('posts')
+  revalidateTag(`post-${id}`)
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/app/api/posts/route.spec.ts
+++ b/apps/web/app/api/posts/route.spec.ts
@@ -11,6 +11,9 @@ const mockEnsureSeries = jest.fn()
 const mockUpsertSeriesTranslation = jest.fn()
 const mockSeriesOrderExistsForSeries = jest.fn()
 
+const mockRevalidateTag = jest.fn()
+
+jest.mock('next/cache', () => ({ revalidateTag: mockRevalidateTag }))
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/db/queries/categories', () => ({
   getCategoryBySlug: mockGetCategoryBySlug,
@@ -394,6 +397,7 @@ describe('POST /api/posts', () => {
         es: validTranslations.es,
       }),
     )
+    expect(mockRevalidateTag).toHaveBeenCalledWith('posts')
   })
 
   it('creates post with ES-only translation', async () => {

--- a/apps/web/app/api/posts/route.ts
+++ b/apps/web/app/api/posts/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -201,5 +202,6 @@ export async function POST(request: Request) {
     }
   }
 
+  revalidateTag('posts')
   return NextResponse.json(post, { status: 201 })
 }

--- a/apps/web/app/api/upload/route.spec.ts
+++ b/apps/web/app/api/upload/route.spec.ts
@@ -3,11 +3,13 @@
  */
 const mockAuth = jest.fn()
 const mockUploadImage = jest.fn()
+const mockLoggerError = jest.fn()
 
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/cloudinary/upload', () => ({
   uploadImage: mockUploadImage,
 }))
+jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
 
 const { POST } = require('./route') as {
   POST: (req: Request) => Promise<Response>
@@ -169,9 +171,10 @@ describe('POST /api/upload', () => {
     )
   })
 
-  it('returns 500 when uploadImage throws', async () => {
+  it('returns 500 and logs error when uploadImage throws', async () => {
     mockAuth.mockResolvedValue({ user: { name: 'admin' } })
-    mockUploadImage.mockRejectedValue(new Error('Cloudinary error'))
+    const err = new Error('Cloudinary error')
+    mockUploadImage.mockRejectedValue(err)
     const response = await POST(
       makeFormDataRequest({
         file: { content: 'data', name: 'photo.jpg', type: 'image/jpeg' },
@@ -180,6 +183,7 @@ describe('POST /api/upload', () => {
     expect(response.status).toBe(500)
     const body = (await response.json()) as { error: string }
     expect(body.error).toBe('Upload failed')
+    expect(mockLoggerError).toHaveBeenCalledWith(err, 'Image upload failed')
   })
 
   it('accepts image/webp and image/gif', async () => {

--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { auth } from '@web/lib/auth/config'
 import { uploadImage } from '@web/lib/cloudinary/upload'
+import { logger } from '@web/lib/logger'
 
 const MAX_SIZE = 10 * 1024 * 1024
 const ALLOWED_TYPES = new Set([
@@ -51,7 +52,8 @@ export async function POST(request: Request) {
       name || undefined,
     )
     return NextResponse.json(result, { status: 201 })
-  } catch {
+  } catch (err) {
+    logger.error(err, 'Image upload failed')
     return NextResponse.json({ error: 'Upload failed' }, { status: 500 })
   }
 }

--- a/apps/web/app/og/route.spec.tsx
+++ b/apps/web/app/og/route.spec.tsx
@@ -2,10 +2,12 @@
  * @jest-environment node
  */
 const mockOgImageTemplate = jest.fn()
+const mockLoggerWarn = jest.fn()
 
 jest.mock('./OgImageTemplate', () => ({
   OgImageTemplate: (props: unknown) => mockOgImageTemplate(props),
 }))
+jest.mock('@web/lib/logger', () => ({ logger: { warn: mockLoggerWarn } }))
 
 jest.mock('next-cloudinary', () => ({
   getCldImageUrl: jest.fn(
@@ -96,14 +98,19 @@ describe('GET /og', () => {
     expect(element.props.cover).toMatch(/^data:image\/jpeg;base64,/)
   })
 
-  it('passes null cover when fetch fails', async () => {
-    mockFetch.mockRejectedValue(new Error('Network error'))
+  it('passes null cover and logs warn when fetch fails', async () => {
+    const err = new Error('Network error')
+    mockFetch.mockRejectedValue(err)
     const { GET } = require('./route')
     await GET(
       new Request('http://localhost/og?title=Test&cover=blog%2Fcover.jpg'),
     )
     const element = mockImageResponse.mock.calls[0][0]
     expect(element.props.cover).toBeNull()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      err,
+      'Failed to fetch OG cover image',
+    )
   })
 
   it('passes null cover when not provided', async () => {

--- a/apps/web/app/og/route.ts
+++ b/apps/web/app/og/route.ts
@@ -3,6 +3,8 @@ import { ImageResponse } from 'next/og'
 import { type NextRequest } from 'next/server'
 import React from 'react'
 
+import { logger } from '@web/lib/logger'
+
 import { OgImageTemplate } from './OgImageTemplate'
 
 async function fetchCoverAsDataUri(publicId: string): Promise<string | null> {
@@ -18,7 +20,8 @@ async function fetchCoverAsDataUri(publicId: string): Promise<string | null> {
     const base64 = Buffer.from(buffer).toString('base64')
     const contentType = res.headers.get('content-type') ?? 'image/jpeg'
     return `data:${contentType};base64,${base64}`
-  } catch {
+  } catch (err) {
+    logger.warn(err, 'Failed to fetch OG cover image')
     return null
   }
 }

--- a/apps/web/i18n/locales/en/admin.json
+++ b/apps/web/i18n/locales/en/admin.json
@@ -8,7 +8,8 @@
     "hidePassword": "hide",
     "signingIn": "Signing in…",
     "signIn": "Sign in",
-    "invalidCredentials": "Invalid credentials"
+    "invalidCredentials": "Invalid credentials",
+    "tooManyAttempts": "Too many attempts, try again in 1 minute"
   },
   "nav": {
     "posts": "Posts",

--- a/apps/web/lib/ratelimit/index.spec.ts
+++ b/apps/web/lib/ratelimit/index.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ */
+const mockSlidingWindow = jest.fn().mockReturnValue('sliding-window-limiter')
+const mockRatelimitConstructor = jest.fn()
+
+jest.mock('@upstash/ratelimit', () => ({
+  Ratelimit: Object.assign(
+    function (...args: unknown[]) {
+      mockRatelimitConstructor(...args)
+      return { _isMockRatelimit: true }
+    },
+    { slidingWindow: mockSlidingWindow },
+  ),
+}))
+
+describe('ratelimit', () => {
+  afterEach(() => {
+    jest.resetModules()
+    mockRatelimitConstructor.mockClear()
+    mockSlidingWindow.mockClear()
+  })
+
+  it('creates Ratelimit instance when redis is available', () => {
+    const mockRedis = { _isMockRedis: true }
+    jest.doMock('../redis', () => ({ redis: mockRedis }))
+    jest.resetModules()
+    jest.doMock('../redis', () => ({ redis: mockRedis }))
+    const { ratelimit } = require('./index') as { ratelimit: unknown }
+    expect(ratelimit).not.toBeNull()
+    expect(mockRatelimitConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ redis: mockRedis }),
+    )
+    expect(mockSlidingWindow).toHaveBeenCalledWith(10, '1m')
+  })
+
+  it('returns null when redis is null', () => {
+    jest.resetModules()
+    jest.doMock('../redis', () => ({ redis: null }))
+    const { ratelimit } = require('./index') as { ratelimit: unknown }
+    expect(ratelimit).toBeNull()
+    expect(mockRatelimitConstructor).not.toHaveBeenCalled()
+  })
+})
+
+export {}

--- a/apps/web/lib/ratelimit/index.ts
+++ b/apps/web/lib/ratelimit/index.ts
@@ -1,0 +1,10 @@
+import { Ratelimit } from '@upstash/ratelimit'
+
+import { redis } from '../redis'
+
+export const ratelimit = redis
+  ? new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(10, '1m'),
+    })
+  : null

--- a/apps/web/lib/redis/index.spec.ts
+++ b/apps/web/lib/redis/index.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+const mockRedisConstructor = jest.fn()
+
+jest.mock('@upstash/redis', () => ({
+  Redis: function (...args: unknown[]) {
+    mockRedisConstructor(...args)
+    return { _isMockRedis: true }
+  },
+}))
+
+describe('redis', () => {
+  const originalUrl = process.env.KV_REST_API_URL
+  const originalToken = process.env.KV_REST_API_TOKEN
+
+  afterEach(() => {
+    process.env.KV_REST_API_URL = originalUrl
+    process.env.KV_REST_API_TOKEN = originalToken
+    jest.resetModules()
+    mockRedisConstructor.mockClear()
+  })
+
+  it('creates Redis instance when both env vars are set', () => {
+    process.env.KV_REST_API_URL = 'https://redis.example.com'
+    process.env.KV_REST_API_TOKEN = 'test-token'
+    jest.resetModules()
+    const { redis } = require('./index') as { redis: unknown }
+    expect(redis).not.toBeNull()
+    expect(mockRedisConstructor).toHaveBeenCalledWith({
+      url: 'https://redis.example.com',
+      token: 'test-token',
+    })
+  })
+
+  it('returns null when KV_REST_API_URL is missing', () => {
+    delete process.env.KV_REST_API_URL
+    process.env.KV_REST_API_TOKEN = 'test-token'
+    jest.resetModules()
+    const { redis } = require('./index') as { redis: unknown }
+    expect(redis).toBeNull()
+    expect(mockRedisConstructor).not.toHaveBeenCalled()
+  })
+
+  it('returns null when KV_REST_API_TOKEN is missing', () => {
+    process.env.KV_REST_API_URL = 'https://redis.example.com'
+    delete process.env.KV_REST_API_TOKEN
+    jest.resetModules()
+    const { redis } = require('./index') as { redis: unknown }
+    expect(redis).toBeNull()
+    expect(mockRedisConstructor).not.toHaveBeenCalled()
+  })
+
+  it('returns null when both env vars are missing', () => {
+    delete process.env.KV_REST_API_URL
+    delete process.env.KV_REST_API_TOKEN
+    jest.resetModules()
+    const { redis } = require('./index') as { redis: unknown }
+    expect(redis).toBeNull()
+  })
+})
+
+export {}

--- a/apps/web/lib/redis/index.ts
+++ b/apps/web/lib/redis/index.ts
@@ -1,0 +1,9 @@
+import { Redis } from '@upstash/redis'
+
+export const redis =
+  process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN
+    ? new Redis({
+        url: process.env.KV_REST_API_URL,
+        token: process.env.KV_REST_API_TOKEN,
+      })
+    : null

--- a/apps/web/proxy.spec.ts
+++ b/apps/web/proxy.spec.ts
@@ -1,35 +1,51 @@
 /**
  * @jest-environment node
  */
+const mockRatelimitLimit = jest.fn()
+const mockRatelimit = { limit: mockRatelimitLimit }
+
 jest.mock('./lib/auth/config', () => ({
   auth: (fn: unknown) => fn,
+}))
+
+jest.mock('./lib/ratelimit', () => ({
+  get ratelimit() {
+    return mockRatelimit
+  },
 }))
 
 type AuthRequest = {
   nextUrl: URL
   url: string
   method: string
+  ip?: string
   auth?: { user?: unknown } | null
 }
 
 const { handleMiddleware } = require('./proxy') as {
-  handleMiddleware: (req: AuthRequest) => Response | undefined
+  handleMiddleware: (req: AuthRequest) => Promise<Response | undefined>
 }
 
 function makeReq(
   pathname: string,
   method = 'GET',
   auth: AuthRequest['auth'] = null,
+  ip?: string,
 ): AuthRequest {
   const url = `http://localhost${pathname}`
-  return { nextUrl: new URL(url), url, method, auth }
+  return { nextUrl: new URL(url), url, method, auth, ip }
 }
 
 describe('handleMiddleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRatelimitLimit.mockResolvedValue({ success: true })
+  })
+
   describe('admin routes', () => {
-    it('redirects unauthenticated requests to /admin/*', () => {
+    it('redirects unauthenticated requests to /admin/*', async () => {
       const req = makeReq('/admin/posts')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeDefined()
       expect((res as Response).status).toBe(307)
       expect((res as Response).headers.get('location')).toContain(
@@ -37,92 +53,133 @@ describe('handleMiddleware', () => {
       )
     })
 
-    it('allows authenticated requests to /admin/*', () => {
+    it('allows authenticated requests to /admin/*', async () => {
       const req = makeReq('/admin/posts', 'GET', { user: { name: 'admin' } })
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
     })
 
-    it('allows all requests to /admin/login', () => {
+    it('allows all requests to /admin/login', async () => {
       const req = makeReq('/admin/login')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
     })
   })
 
   describe('protected API routes', () => {
-    it('returns 401 for unauthenticated POST /api/posts', () => {
+    it('returns 401 for unauthenticated POST /api/posts', async () => {
       const req = makeReq('/api/posts', 'POST')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('returns 401 for unauthenticated PUT /api/posts/id', () => {
+    it('returns 401 for unauthenticated PUT /api/posts/id', async () => {
       const req = makeReq('/api/posts/some-id', 'PUT')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('returns 401 for unauthenticated DELETE /api/posts/id', () => {
+    it('returns 401 for unauthenticated DELETE /api/posts/id', async () => {
       const req = makeReq('/api/posts/some-id', 'DELETE')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('returns 401 for unauthenticated POST /api/categories', () => {
+    it('returns 401 for unauthenticated POST /api/categories', async () => {
       const req = makeReq('/api/categories', 'POST')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('returns 401 for unauthenticated PUT /api/categories/slug', () => {
+    it('returns 401 for unauthenticated PUT /api/categories/slug', async () => {
       const req = makeReq('/api/categories/engineering', 'PUT')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('returns 401 for unauthenticated DELETE /api/categories/slug', () => {
+    it('returns 401 for unauthenticated DELETE /api/categories/slug', async () => {
       const req = makeReq('/api/categories/engineering', 'DELETE')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('returns 401 for unauthenticated POST /api/upload', () => {
+    it('returns 401 for unauthenticated POST /api/upload', async () => {
       const req = makeReq('/api/upload', 'POST')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect((res as Response).status).toBe(401)
     })
 
-    it('allows authenticated write requests to /api/posts', () => {
+    it('allows authenticated write requests to /api/posts', async () => {
       const req = makeReq('/api/posts', 'POST', { user: { name: 'admin' } })
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
     })
 
-    it('allows authenticated write requests to /api/categories', () => {
+    it('allows authenticated write requests to /api/categories', async () => {
       const req = makeReq('/api/categories', 'POST', {
         user: { name: 'admin' },
       })
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
     })
 
-    it('allows GET requests to /api/posts without auth', () => {
+    it('allows GET requests to /api/posts without auth', async () => {
       const req = makeReq('/api/posts', 'GET')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
     })
 
-    it('allows GET requests to /api/categories without auth', () => {
+    it('allows GET requests to /api/categories without auth', async () => {
       const req = makeReq('/api/categories', 'GET')
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
     })
 
-    it('allows authenticated POST /api/upload', () => {
+    it('allows authenticated POST /api/upload', async () => {
       const req = makeReq('/api/upload', 'POST', { user: { name: 'admin' } })
-      const res = handleMiddleware(req)
+      const res = await handleMiddleware(req)
       expect(res).toBeUndefined()
+    })
+  })
+
+  describe('rate limiting on /api/auth/callback/credentials', () => {
+    it('allows request when rate limit check passes', async () => {
+      mockRatelimitLimit.mockResolvedValue({ success: true })
+      const req = makeReq(
+        '/api/auth/callback/credentials',
+        'POST',
+        null,
+        '1.2.3.4',
+      )
+      const res = await handleMiddleware(req)
+      expect(res).toBeUndefined()
+      expect(mockRatelimitLimit).toHaveBeenCalledWith('1.2.3.4')
+    })
+
+    it('returns 429 with Retry-After header when rate limit exceeded', async () => {
+      mockRatelimitLimit.mockResolvedValue({ success: false })
+      const req = makeReq(
+        '/api/auth/callback/credentials',
+        'POST',
+        null,
+        '1.2.3.4',
+      )
+      const res = await handleMiddleware(req)
+      expect((res as Response).status).toBe(429)
+      expect((res as Response).headers.get('Retry-After')).toBe('60')
+    })
+
+    it('falls back to 127.0.0.1 when ip is undefined', async () => {
+      mockRatelimitLimit.mockResolvedValue({ success: true })
+      const req = makeReq('/api/auth/callback/credentials', 'POST')
+      await handleMiddleware(req)
+      expect(mockRatelimitLimit).toHaveBeenCalledWith('127.0.0.1')
+    })
+
+    it('skips rate limit check for GET requests', async () => {
+      const req = makeReq('/api/auth/callback/credentials', 'GET')
+      await handleMiddleware(req)
+      expect(mockRatelimitLimit).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/web/proxy.spec.ts
+++ b/apps/web/proxy.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 const mockRatelimitLimit = jest.fn()
-const mockRatelimit = { limit: mockRatelimitLimit }
+let mockRatelimit: { limit: jest.Mock } | null = { limit: mockRatelimitLimit }
 
 jest.mock('./lib/auth/config', () => ({
   auth: (fn: unknown) => fn,
@@ -39,6 +39,7 @@ function makeReq(
 describe('handleMiddleware', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockRatelimit = { limit: mockRatelimitLimit }
     mockRatelimitLimit.mockResolvedValue({ success: true })
   })
 
@@ -179,6 +180,14 @@ describe('handleMiddleware', () => {
     it('skips rate limit check for GET requests', async () => {
       const req = makeReq('/api/auth/callback/credentials', 'GET')
       await handleMiddleware(req)
+      expect(mockRatelimitLimit).not.toHaveBeenCalled()
+    })
+
+    it('allows request when ratelimit is null (Redis not configured)', async () => {
+      mockRatelimit = null
+      const req = makeReq('/api/auth/callback/credentials', 'POST')
+      const res = await handleMiddleware(req)
+      expect(res).toBeUndefined()
       expect(mockRatelimitLimit).not.toHaveBeenCalled()
     })
   })

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -2,12 +2,28 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
 import { auth } from './lib/auth/config'
+import { ratelimit } from './lib/ratelimit'
 
 type AuthRequest = NextRequest & { auth?: { user?: unknown } | null }
 
-export function handleMiddleware(req: AuthRequest): Response | undefined {
+export async function handleMiddleware(
+  req: AuthRequest,
+): Promise<Response | undefined> {
   const { pathname } = req.nextUrl
   const isAuthenticated = !!req.auth
+
+  if (pathname === '/api/auth/callback/credentials' && req.method === 'POST') {
+    if (ratelimit) {
+      const ip = req.ip ?? '127.0.0.1'
+      const { success } = await ratelimit.limit(ip)
+      if (!success) {
+        return NextResponse.json(
+          { error: 'Too many requests' },
+          { status: 429, headers: { 'Retry-After': '60' } },
+        )
+      }
+    }
+  }
 
   if (pathname.startsWith('/admin') && !pathname.startsWith('/admin/login')) {
     if (!isAuthenticated) {
@@ -35,5 +51,6 @@ export const config = {
     '/api/posts/:path*',
     '/api/categories/:path*',
     '/api/upload',
+    '/api/auth/callback/credentials',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-query-devtools": "5.100.10",
     "@testing-library/user-event": "14.6.1",
+    "@upstash/ratelimit": "2.0.8",
+    "@upstash/redis": "1.38.0",
     "accept-language": "3.0.20",
     "axios": "1.16.1",
     "bcryptjs": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7353,6 +7353,8 @@ __metadata:
     "@types/testing-library__jest-dom": 5.14.9
     "@typescript-eslint/eslint-plugin": 8.59.2
     "@typescript-eslint/parser": 8.59.2
+    "@upstash/ratelimit": 2.0.8
+    "@upstash/redis": 1.38.0
     accept-language: 3.0.20
     axios: 1.16.1
     babel-jest: 30.4.0
@@ -9028,6 +9030,35 @@ __metadata:
   version: 1.11.1
   resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.11.1"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@upstash/core-analytics@npm:^0.0.10":
+  version: 0.0.10
+  resolution: "@upstash/core-analytics@npm:0.0.10"
+  dependencies:
+    "@upstash/redis": ^1.28.3
+  checksum: 5b435a5e67666a6ecb19e59ab73f314124634fdadb66390f8b2d6f7e20cac461262e5b81d113d77a5d093d8d11b2cfe3ecd5c573cde77505557f8bbf0f8b1e27
+  languageName: node
+  linkType: hard
+
+"@upstash/ratelimit@npm:2.0.8":
+  version: 2.0.8
+  resolution: "@upstash/ratelimit@npm:2.0.8"
+  dependencies:
+    "@upstash/core-analytics": ^0.0.10
+  peerDependencies:
+    "@upstash/redis": ^1.34.3
+  checksum: c39b59f94a05c8c3b9cd7dab5c754dd5bf94bab42894820781a21521de3024ccae64711967253aad7b85dc972bbfe5d1cc6b44f012f064b410f319787d564434
+  languageName: node
+  linkType: hard
+
+"@upstash/redis@npm:1.38.0, @upstash/redis@npm:^1.28.3":
+  version: 1.38.0
+  resolution: "@upstash/redis@npm:1.38.0"
+  dependencies:
+    uncrypto: ^0.1.3
+  checksum: 8bba049e67a47515b628b4c431bc45f7a8e8695e448dbafdb34ed2b2a23b865a9b6fad49f23d4952076760c71481ff2ebb62f26f303f47576712d587e3368c54
   languageName: node
   linkType: hard
 
@@ -26185,6 +26216,13 @@ __metadata:
   peerDependencies:
     react: ">=15.0.0"
   checksum: 3345c0c1916193ddb9cc6f2b78711dc9f22b919d780485e15b95690722e9d1797fc702c4ebb30c0acaae6a772b865d0a9ddc83fa1da44958f089aee78f2f5eab
+  languageName: node
+  linkType: hard
+
+"uncrypto@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "uncrypto@npm:0.1.3"
+  checksum: 07160e08806dd6cea16bb96c3fd54cd70fc801e02fc3c6f86980144d15c9ebbd1c55587f7280a207b3af6cd34901c0d0b77ada5a02c2f7081a033a05acf409e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #84

## What

**ISR / Cache revalidation**
- Blog listing page: `revalidate = 60` (1-minute background revalidation)
- Blog post redirect page (`/[lng]/blog/[id]`): `revalidate = 3600`
- Blog post detail page (`/[lng]/blog/[id]/[slug]`): `revalidate = 3600` (was 60)
- On-demand tag invalidation added to all write paths:
  - `POST /api/posts` → invalidates `posts`
  - `PUT /api/posts/[id]` → invalidates `posts` + `post-{id}`
  - `DELETE /api/posts/[id]` (soft + hard) → invalidates `posts` + `post-{id}`
  - `GET /api/cron/publish` → invalidates `posts` + each published `post-{id}`

**Auth rate limiting**
- New `lib/redis/index.ts`: lazily creates `@upstash/redis` client from `KV_REST_API_URL` / `KV_REST_API_TOKEN`; returns `null` when env vars are absent (local dev without Redis)
- New `lib/ratelimit/index.ts`: sliding-window limiter, 10 requests / 1 minute per IP
- Middleware (`proxy.ts`) checks rate limit on `POST /api/auth/callback/credentials`; returns `429` with `Retry-After: 60` header when exceeded
- Login form shows a dedicated "Too many attempts, try again in 1 minute" error on 429

## Infrastructure

Upstash Redis connected via Vercel Marketplace. Required env vars added to all environments:

```
KV_REST_API_URL=
KV_REST_API_TOKEN=
```

`.env.example` updated with these keys and instructions.

## Tests

- 100% coverage maintained across all modified files
- New unit tests: `lib/redis`, `lib/ratelimit`
- `proxy.spec.ts` updated: all middleware calls made async, rate-limit pass/fail/fallback-IP/GET-skip cases added
- API route specs updated: `revalidateTag` mock + assertions for `POST /api/posts`, `PUT` + both `DELETE` paths of `/api/posts/[id]`, and the cron job
- `LoginForm.spec.tsx`: 429 error message test added