### PR TITLE
fix: update E2E tests for a11y heading and portals changes

### DIFF
--- a/apps/web-e2e/src/e2e/contact.cy.ts
+++ b/apps/web-e2e/src/e2e/contact.cy.ts
@@ -44,7 +44,7 @@ describe('Contact page', () => {
 
   it('should show an image carousel', () => {
     getTitle({ timeout: 6000 }).contains('Saúl de León Guerrero')
-    cy.get('h3').should('have.text', 'Software Engineer')
+    cy.get('h2').should('have.text', 'Software Engineer')
     cy.get('[alt="My profile picture 1"]').should('have.css', 'opacity', '1')
     cy.get('[alt="My profile picture 2"]').should('have.css', 'opacity', '0')
     cy.get('[alt="My profile picture 2"]', { timeout: 60000 }).should(
@@ -56,7 +56,7 @@ describe('Contact page', () => {
 
   it('should show a hidden image', () => {
     getTitle({ timeout: 6000 }).contains('Saúl de León Guerrero')
-    cy.get('h3').should('have.text', 'Software Engineer')
+    cy.get('h2').should('have.text', 'Software Engineer')
     cy.get('[alt="My profile picture 1"]').as('btn').click({ force: true })
     cy.get('[alt="My toothless profile picture"]')
   })

--- a/apps/web-e2e/src/e2e/contact.cy.ts
+++ b/apps/web-e2e/src/e2e/contact.cy.ts
@@ -45,19 +45,27 @@ describe('Contact page', () => {
   it('should show an image carousel', () => {
     getTitle({ timeout: 6000 }).contains('Saúl de León Guerrero')
     cy.contains('h2', 'Software Engineer')
-    cy.get('[alt="My profile picture 1"]').should('have.css', 'opacity', '1')
-    cy.get('[alt="My profile picture 2"]').should('have.css', 'opacity', '0')
-    cy.get('[alt="My profile picture 2"]', { timeout: 60000 }).should(
+    cy.get('[alt="Saúl de León Guerrero, portrait 1"]').should(
       'have.css',
       'opacity',
       '1',
     )
+    cy.get('[alt="Saúl de León Guerrero, portrait 2"]').should(
+      'have.css',
+      'opacity',
+      '0',
+    )
+    cy.get('[alt="Saúl de León Guerrero, portrait 2"]', {
+      timeout: 60000,
+    }).should('have.css', 'opacity', '1')
   })
 
   it('should show a hidden image', () => {
     getTitle({ timeout: 6000 }).contains('Saúl de León Guerrero')
     cy.contains('h2', 'Software Engineer')
-    cy.get('[alt="My profile picture 1"]').as('btn').click({ force: true })
+    cy.get('[alt="Saúl de León Guerrero, portrait 1"]')
+      .as('btn')
+      .click({ force: true })
     cy.get('[alt="My toothless profile picture"]')
   })
 })

--- a/apps/web-e2e/src/e2e/contact.cy.ts
+++ b/apps/web-e2e/src/e2e/contact.cy.ts
@@ -44,7 +44,7 @@ describe('Contact page', () => {
 
   it('should show an image carousel', () => {
     getTitle({ timeout: 6000 }).contains('Saúl de León Guerrero')
-    cy.get('h2').should('have.text', 'Software Engineer')
+    cy.contains('h2', 'Software Engineer')
     cy.get('[alt="My profile picture 1"]').should('have.css', 'opacity', '1')
     cy.get('[alt="My profile picture 2"]').should('have.css', 'opacity', '0')
     cy.get('[alt="My profile picture 2"]', { timeout: 60000 }).should(
@@ -56,7 +56,7 @@ describe('Contact page', () => {
 
   it('should show a hidden image', () => {
     getTitle({ timeout: 6000 }).contains('Saúl de León Guerrero')
-    cy.get('h2').should('have.text', 'Software Engineer')
+    cy.contains('h2', 'Software Engineer')
     cy.get('[alt="My profile picture 1"]').as('btn').click({ force: true })
     cy.get('[alt="My toothless profile picture"]')
   })

--- a/apps/web-e2e/src/e2e/experience.cy.ts
+++ b/apps/web-e2e/src/e2e/experience.cy.ts
@@ -28,6 +28,6 @@ describe('Experience page', () => {
 
   it('should show multiple portals', () => {
     getTitle({ timeout: 6000 }).contains('Experience')
-    cy.findAllByRole('presentation').should('have.length', 9)
+    cy.get('[data-testid="portals"]').should('have.length', 9)
   })
 })

--- a/apps/web/app/[lng]/experience/__snapshots__/page.spec.tsx.snap
+++ b/apps/web/app/[lng]/experience/__snapshots__/page.spec.tsx.snap
@@ -1229,6 +1229,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -2001,6 +2002,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -2758,6 +2760,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -3543,6 +3546,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -4122,6 +4126,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -4922,6 +4927,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -5643,6 +5649,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -6288,6 +6295,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -6861,6 +6869,7 @@ exports[`[lng]/experience route -  page should render successfully 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"

--- a/apps/web/components/ExperiencePage/__snapshots__/ExperiencePage.spec.tsx.snap
+++ b/apps/web/components/ExperiencePage/__snapshots__/ExperiencePage.spec.tsx.snap
@@ -1211,6 +1211,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -1983,6 +1984,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -2740,6 +2742,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -3525,6 +3528,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -4104,6 +4108,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -4904,6 +4909,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -5625,6 +5631,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -6270,6 +6277,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"
@@ -6843,6 +6851,7 @@ exports[`ExperiencePage should render successfully in English 1`] = `
         >
           <div
             class="c16 c17"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"

--- a/apps/web/components/ExperiencePage/components/ExperienceItem/ExperienceItem.tsx
+++ b/apps/web/components/ExperiencePage/components/ExperienceItem/ExperienceItem.tsx
@@ -81,7 +81,7 @@ export function ExperienceItem({
       </StyledExperienceHeader>
       <StyledExperienceInfo>
         <StyledExperiencePortal>
-          <StyledPortals>
+          <StyledPortals data-testid="portals">
             <ul aria-label={ariaLabel}>
               {technologies
                 .map((tech) => animatedItemMap[tech])

--- a/apps/web/components/ExperiencePage/components/ExperienceItem/__snapshots__/ExperienceItem.spec.tsx.snap
+++ b/apps/web/components/ExperiencePage/components/ExperienceItem/__snapshots__/ExperienceItem.spec.tsx.snap
@@ -544,6 +544,7 @@ exports[`ExperienceItem should render successfully 1`] = `
         >
           <div
             class="c9 c10"
+            data-testid="portals"
           >
             <div
               aria-hidden="true"


### PR DESCRIPTION
## Summary

- Update `contact.cy.ts` to look for `h2` instead of `h3` — the "Software Engineer" heading was promoted when a visually-hidden `h1` was added in the a11y commit
- Add `data-testid="portals"` to `<StyledPortals>` in `ExperienceItem` so the E2E test can count portal instances without depending on the removed `role="presentation"` attribute
- Update `experience.cy.ts` to use `[data-testid="portals"]` selector instead of `findAllByRole('presentation')`
- Update snapshots

## Test plan

- [x] `contact.cy.ts` — "should show an image carousel" and "should show a hidden image" pass with `h2` selector
- [x] `experience.cy.ts` — "should show multiple portals" passes with `[data-testid="portals"]` selector (finds 9 portals)
- [x] All 1270 unit tests pass