### PR TITLE
feat: add search input to admin images manager

### DIFF
--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.spec.tsx
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.spec.tsx
@@ -30,6 +30,8 @@ jest.mock('@web/i18n/client', () => ({
         'images.emptyState': 'No images yet. Upload your first image.',
         'images.deleteConfirm': 'Delete this image? This cannot be undone.',
         'images.upload.error': 'Upload failed, please try again',
+        'images.searchPlaceholder': 'Search images…',
+        'images.noResults': 'No images match your search.',
         'images.listError': 'Failed to load images, please try again',
         'images.deleteError': 'Delete failed, please try again',
         'images.picker.loading': 'Loading…',
@@ -398,6 +400,70 @@ describe('ImageManager', () => {
         'Rename failed, please try again',
       ),
     )
+  })
+
+  it('renders search input', async () => {
+    renderApp(<ImageManager />)
+    expect(await screen.findByTestId('image-grid')).toBeInTheDocument()
+    expect(screen.getByTestId('search-input')).toBeInTheDocument()
+  })
+
+  it('filters images by search query', async () => {
+    renderApp(<ImageManager />)
+    expect(await screen.findByTestId('image-grid')).toBeInTheDocument()
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'photo1' },
+    })
+    expect(
+      screen.getByTestId('image-card-sawl.dev - blog/photo1'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('image-card-sawl.dev - blog/photo2'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows no-results state when search matches nothing', async () => {
+    renderApp(<ImageManager />)
+    expect(await screen.findByTestId('image-grid')).toBeInTheDocument()
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'nonexistent' },
+    })
+    expect(screen.getByTestId('no-results-state')).toBeInTheDocument()
+    expect(screen.getByTestId('no-results-state')).toHaveTextContent(
+      'No images match your search.',
+    )
+    expect(screen.queryByTestId('image-grid')).not.toBeInTheDocument()
+  })
+
+  it('search is case-insensitive', async () => {
+    renderApp(<ImageManager />)
+    expect(await screen.findByTestId('image-grid')).toBeInTheDocument()
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'PHOTO1' },
+    })
+    expect(
+      screen.getByTestId('image-card-sawl.dev - blog/photo1'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('image-card-sawl.dev - blog/photo2'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows all images when search is cleared', async () => {
+    renderApp(<ImageManager />)
+    expect(await screen.findByTestId('image-grid')).toBeInTheDocument()
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'photo1' },
+    })
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: '' },
+    })
+    expect(
+      screen.getByTestId('image-card-sawl.dev - blog/photo1'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('image-card-sawl.dev - blog/photo2'),
+    ).toBeInTheDocument()
   })
 })
 

--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 import { Button } from '@sdlgr/button'
+import { Input } from '@sdlgr/input'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -44,6 +45,12 @@ export const StyledRefreshButton = styled(Button).attrs({
   &:hover {
     opacity: 0.6;
   }
+`
+
+export const StyledSearchInput = styled(Input)`
+  font-size: 0.75rem;
+  width: 220px;
+  padding: 0.375rem 0;
 `
 
 export const StyledGrid = styled.div`

--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
@@ -6,14 +6,14 @@ import { Input } from '@sdlgr/input'
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 0;
   padding: 2rem 0;
 `
 
 export const StyledHeader = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 `
 
 export const StyledToolbar = styled.div`
@@ -21,6 +21,9 @@ export const StyledToolbar = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
+  flex-wrap: wrap;
 `
 
 export const StyledTitle = styled.h1`

--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
@@ -13,7 +13,7 @@ export const StyledWrapper = styled.div`
 export const StyledHeader = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 2rem;
 `
 
 export const StyledToolbar = styled.div`

--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.styles.ts
@@ -12,7 +12,13 @@ export const StyledWrapper = styled.div`
 
 export const StyledHeader = styled.div`
   display: flex;
-  align-items: baseline;
+  flex-direction: column;
+  gap: 0.75rem;
+`
+
+export const StyledToolbar = styled.div`
+  display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 1rem;
 `

--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.tsx
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.tsx
@@ -19,6 +19,7 @@ import {
   StyledHeader,
   StyledLoading,
   StyledRefreshButton,
+  StyledSearchInput,
   StyledTitle,
   StyledUploadButton,
   StyledWrapper,
@@ -30,6 +31,7 @@ export function ImageManager() {
   const { t } = useClientTranslation('admin')
   const queryClient = useQueryClient()
   const [isUploadOpen, setIsUploadOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [editTargetId, setEditTargetId] = useState<string | null>(null)
@@ -57,6 +59,12 @@ export function ImageManager() {
     : null
 
   const editTarget = images.find((img) => img.publicId === editTargetId) ?? null
+
+  const filteredImages = search
+    ? images.filter((img) =>
+        img.publicId.toLowerCase().includes(search.toLowerCase()),
+      )
+    : images
 
   const renameMutation = useMutation({
     mutationFn: async ({
@@ -123,6 +131,13 @@ export function ImageManager() {
     <StyledWrapper data-testid="image-manager">
       <StyledHeader>
         <StyledTitle>{t('images.title')}</StyledTitle>
+        <StyledSearchInput
+          type="search"
+          placeholder={t('images.searchPlaceholder')}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          data-testid="search-input"
+        />
         <StyledActions>
           <StyledRefreshButton
             variant="contained"
@@ -162,9 +177,18 @@ export function ImageManager() {
         </StyledEmptyState>
       )}
 
-      {!isLoading && !displayError && images.length > 0 && (
+      {!isLoading &&
+        !displayError &&
+        images.length > 0 &&
+        filteredImages.length === 0 && (
+          <StyledEmptyState data-testid="no-results-state">
+            {t('images.noResults')}
+          </StyledEmptyState>
+        )}
+
+      {!isLoading && !displayError && filteredImages.length > 0 && (
         <StyledGrid data-testid="image-grid">
-          {images.map((image) => (
+          {filteredImages.map((image) => (
             <ImageCard
               key={image.publicId}
               image={image}

--- a/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.tsx
+++ b/apps/web/app/admin/(auth)/images/components/ImageManager/ImageManager.tsx
@@ -21,6 +21,7 @@ import {
   StyledRefreshButton,
   StyledSearchInput,
   StyledTitle,
+  StyledToolbar,
   StyledUploadButton,
   StyledWrapper,
 } from './ImageManager.styles'
@@ -131,34 +132,36 @@ export function ImageManager() {
     <StyledWrapper data-testid="image-manager">
       <StyledHeader>
         <StyledTitle>{t('images.title')}</StyledTitle>
-        <StyledSearchInput
-          type="search"
-          placeholder={t('images.searchPlaceholder')}
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          data-testid="search-input"
-        />
-        <StyledActions>
-          <StyledRefreshButton
-            variant="contained"
-            size="sm"
-            onClick={() => {
-              setDeleteError(null)
-              void refetch()
-            }}
-            data-testid="refresh-button"
-          >
-            {t('refresh')}
-          </StyledRefreshButton>
-          <StyledUploadButton
-            variant="inverted"
-            size="sm"
-            onClick={() => setIsUploadOpen(true)}
-            data-testid="upload-button"
-          >
-            {t('images.uploadButton')}
-          </StyledUploadButton>
-        </StyledActions>
+        <StyledToolbar>
+          <StyledSearchInput
+            type="search"
+            placeholder={t('images.searchPlaceholder')}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            data-testid="search-input"
+          />
+          <StyledActions>
+            <StyledRefreshButton
+              variant="contained"
+              size="sm"
+              onClick={() => {
+                setDeleteError(null)
+                void refetch()
+              }}
+              data-testid="refresh-button"
+            >
+              {t('refresh')}
+            </StyledRefreshButton>
+            <StyledUploadButton
+              variant="inverted"
+              size="sm"
+              onClick={() => setIsUploadOpen(true)}
+              data-testid="upload-button"
+            >
+              {t('images.uploadButton')}
+            </StyledUploadButton>
+          </StyledActions>
+        </StyledToolbar>
       </StyledHeader>
 
       {isLoading && (

--- a/apps/web/i18n/locales/en/admin.json
+++ b/apps/web/i18n/locales/en/admin.json
@@ -142,6 +142,8 @@
       "saving": "Saving…",
       "error": "Rename failed, please try again"
     },
+    "searchPlaceholder": "Search images…",
+    "noResults": "No images match your search.",
     "listError": "Failed to load images, please try again",
     "deleteError": "Delete failed, please try again",
     "upload": {


### PR DESCRIPTION
## Summary

- Search input in the images manager header filters the loaded image list by `publicId` (case-insensitive, client-side)
- Shows a "no results" state when the query matches nothing (distinct from the empty state when no images exist at all)
- Follows the same `@sdlgr/input` + `StyledSearchInput` pattern used in PostTable
- Adds `images.searchPlaceholder` and `images.noResults` i18n keys

## Test plan

- [x] Search input renders in the images manager header
- [x] Typing filters cards in real-time (case-insensitive)
- [x] No-results state appears when query matches nothing
- [x] Clearing the input restores all images
- [x] 100% unit test coverage maintained (1275 tests pass)