### PR TITLE
fix: correct X.com share URL and enrich blog post OG/Twitter metadata

### DIFF
--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -106,7 +106,7 @@ export async function generateMetadata({ params }: RouteProps) {
       alternateLocale: ogLocaleAlternate(lng),
       images: [{ url: ogImageUrl, width: 1200, height: 630 }],
       publishedTime: post.publishedAt?.toISOString(),
-      modifiedTime: post.updatedAt?.toISOString(),
+      modifiedTime: post.updatedAt.toISOString(),
       authors: [post.author],
       section: categoryName,
       tags: post.tags,
@@ -114,7 +114,7 @@ export async function generateMetadata({ params }: RouteProps) {
     twitter: {
       card: 'summary_large_image' as const,
       title: post.title,
-      description: post.excerpt ?? undefined,
+      description: post.excerpt,
       images: [{ url: ogImageUrl, width: 1200, height: 630, alt: post.title }],
     },
     alternates: {

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -92,20 +92,30 @@ export async function generateMetadata({ params }: RouteProps) {
   if (post.coverImage) ogParams.set('cover', post.coverImage)
   if (post.category) ogParams.set('category', categoryName)
   const ogImageUrl = `${deploymentUrl}/og?${ogParams.toString()}`
+  const postUrl = `${deploymentUrl}/${lng}/blog/${postNumber}/${post.slug}`
 
   return {
     title: post.title,
     description: post.excerpt,
     openGraph: {
+      type: 'article',
+      url: postUrl,
       title: post.title,
       description: post.excerpt,
       locale: ogLocale(lng),
-      localeAlternate: ogLocaleAlternate(lng),
+      alternateLocale: ogLocaleAlternate(lng),
       images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+      publishedTime: post.publishedAt?.toISOString(),
+      modifiedTime: post.updatedAt?.toISOString(),
+      authors: [post.author],
+      section: categoryName,
+      tags: post.tags,
     },
     twitter: {
       card: 'summary_large_image' as const,
-      images: [ogImageUrl],
+      title: post.title,
+      description: post.excerpt ?? undefined,
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: post.title }],
     },
     alternates: {
       ...buildAlternates(lng, ownPath),

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
@@ -106,7 +106,8 @@ const publishedPost = {
   category: 'Tech',
   tags: ['next.js', 'react'],
   author: 'Jane Doe',
-  publishedAt: new Date('2024-01-01'),
+  publishedAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-06-15T00:00:00.000Z'),
   content: 'Hello world content',
   seriesId: null,
   seriesOrder: null,
@@ -438,7 +439,62 @@ describe('[lng]/blog/[id]/[slug] - BlogPostPage', () => {
         params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
       })
       expect(meta.twitter.card).toBe('summary_large_image')
-      expect(meta.twitter.images[0]).toContain('/og?')
+      expect(meta.twitter.title).toBe('My Test Post')
+      expect(meta.twitter.description).toBe('A great post about testing')
+      expect(meta.twitter.images[0].url).toContain('/og?')
+      expect(meta.twitter.images[0]).toMatchObject({
+        width: 1200,
+        height: 630,
+        alt: 'My Test Post',
+      })
+    })
+
+    it('includes article og type and url', async () => {
+      process.env.BASE_URL = 'https://example.com'
+      mockGetPostByNumber.mockResolvedValue(publishedPost)
+      const { generateMetadata } = require('./page.next')
+      const meta = await generateMetadata({
+        params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
+      })
+      expect(meta.openGraph.type).toBe('article')
+      expect(meta.openGraph.url).toBe(
+        'https://example.com/en/blog/1/my-test-post',
+      )
+      delete process.env.BASE_URL
+    })
+
+    it('includes alternateLocale in openGraph', async () => {
+      mockGetPostByNumber.mockResolvedValue(publishedPost)
+      const { generateMetadata } = require('./page.next')
+      const meta = await generateMetadata({
+        params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
+      })
+      expect(meta.openGraph.alternateLocale).toEqual(['es_ES'])
+    })
+
+    it('includes article metadata in openGraph', async () => {
+      mockGetPostByNumber.mockResolvedValue(publishedPost)
+      const { generateMetadata } = require('./page.next')
+      const meta = await generateMetadata({
+        params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
+      })
+      expect(meta.openGraph.publishedTime).toBe('2024-01-01T00:00:00.000Z')
+      expect(meta.openGraph.modifiedTime).toBe('2024-06-15T00:00:00.000Z')
+      expect(meta.openGraph.authors).toEqual(['Jane Doe'])
+      expect(meta.openGraph.section).toBe('Technology')
+      expect(meta.openGraph.tags).toEqual(['next.js', 'react'])
+    })
+
+    it('omits publishedTime when publishedAt is null', async () => {
+      mockGetPostByNumber.mockResolvedValue({
+        ...publishedPost,
+        publishedAt: null,
+      })
+      const { generateMetadata } = require('./page.next')
+      const meta = await generateMetadata({
+        params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
+      })
+      expect(meta.openGraph.publishedTime).toBeUndefined()
     })
 
     it('does not include cover in OG URL when post has no coverImage', async () => {

--- a/libs/post-hero/src/lib/ShareButtons/ShareButtons.spec.tsx
+++ b/libs/post-hero/src/lib/ShareButtons/ShareButtons.spec.tsx
@@ -29,6 +29,7 @@ describe('ShareButtons', () => {
   it('renders all platform links', () => {
     renderWithTheme(<ShareButtons {...defaultProps} />)
     expect(screen.getByRole('link', { name: 'LinkedIn' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'X' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Facebook' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'WhatsApp' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Telegram' })).toBeInTheDocument()
@@ -79,6 +80,14 @@ describe('ShareButtons', () => {
     expect(screen.getByRole('link', { name: 'Facebook' })).toHaveAttribute(
       'href',
       expect.stringContaining('facebook.com'),
+    )
+  })
+
+  it('X link contains x.com/intent/tweet', () => {
+    renderWithTheme(<ShareButtons {...defaultProps} />)
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('x.com/intent/tweet'),
     )
   })
 

--- a/libs/post-hero/src/lib/ShareButtons/ShareButtons.tsx
+++ b/libs/post-hero/src/lib/ShareButtons/ShareButtons.tsx
@@ -41,7 +41,7 @@ const PLATFORMS = [
     name: 'X',
     Icon: XComIcon,
     getHref: (url: string, title: string) =>
-      `https://x.com/intent/post?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
+      `https://x.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
   },
   {
     name: 'Facebook',

--- a/libs/post-hero/src/lib/ShareButtons/__snapshots__/ShareButtons.spec.tsx.snap
+++ b/libs/post-hero/src/lib/ShareButtons/__snapshots__/ShareButtons.spec.tsx.snap
@@ -110,7 +110,7 @@ exports[`ShareButtons matches snapshot 1`] = `
           <a
             aria-label="X"
             class="c3"
-            href="https://x.com/intent/post?url=https%3A%2F%2Fexample.com%2Fpost&text=My%20Post%20Title"
+            href="https://x.com/intent/tweet?url=https%3A%2F%2Fexample.com%2Fpost&text=My%20Post%20Title"
             rel="noopener noreferrer"
             target="_blank"
           >


### PR DESCRIPTION
## Summary

- Fix X.com share URL: `intent/post` → `intent/tweet` (correct endpoint)
- Fix `localeAlternate` → `alternateLocale` in OpenGraph metadata — was silently ignored, so `og:locale:alternate` was never rendered
- Add `og:type: 'article'` and `og:url` — Facebook needs both for correct article sharing and URL deduplication
- Enrich Twitter card: explicit `title`, `description`, and image `alt`/`width`/`height`
- Add article-specific OG tags: `article:published_time`, `article:modified_time`, `article:author`, `article:section`, `article:tag`

## Test plan

- [ ] All 40 blog post page tests pass
- [ ] All 35 post-hero/ShareButtons tests pass (snapshot updated for new X URL)
- [ ] Validate blog post on Twitter Card validator — `og:locale:alternate`, `og:url`, `og:type`, `article:*` tags all present
- [ ] Click X share button — URL uses `intent/tweet`
- [ ] Click Facebook share button — share dialog shows correct article preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)