### PR TITLE
fix: add mainEntity to home ProfilePage schema

### DIFF
--- a/apps/web/app/[lng]/(home)/__snapshots__/page.spec.tsx.snap
+++ b/apps/web/app/[lng]/(home)/__snapshots__/page.spec.tsx.snap
@@ -596,7 +596,7 @@ exports[`[lng] route - Page should render successfully 1`] = `
       data-testid="json-ld"
       type="application/ld+json"
     >
-      {"@context":"https://schema.org","@type":"ProfilePage","name":"Saúl de León Guerrero — Front-End Software Engineer","url":"https://www.sawl.dev/en/","description":"Personal portfolio of Saúl de León Guerrero, Software Engineer","inLanguage":"en-US","isPartOf":{"@type":"WebSite","url":"https://www.sawl.dev"}}
+      {"@context":"https://schema.org","@type":"ProfilePage","name":"Saúl de León Guerrero — Front-End Software Engineer","url":"https://www.sawl.dev/en/","description":"Personal portfolio of Saúl de León Guerrero, Software Engineer","inLanguage":"en-US","isPartOf":{"@type":"WebSite","url":"https://www.sawl.dev"},"mainEntity":{"@type":"Person","name":"Saúl de León Guerrero","url":"https://www.sawl.dev"}}
     </script>
     <div
       class="c0"

--- a/apps/web/app/[lng]/(home)/page.next.tsx
+++ b/apps/web/app/[lng]/(home)/page.next.tsx
@@ -79,6 +79,11 @@ export default async function Page({ params }: RouteProps) {
       'Personal portfolio of Saúl de León Guerrero, Software Engineer',
     inLanguage: inLanguage(lng),
     isPartOf: { '@type': 'WebSite', url: 'https://www.sawl.dev' },
+    mainEntity: {
+      '@type': 'Person',
+      name: 'Saúl de León Guerrero',
+      url: 'https://www.sawl.dev',
+    },
   }
 
   return (


### PR DESCRIPTION
## Summary

- Google Search Console flagged `mainEntity` as missing on the home page `ProfilePage` structured data
- Added `mainEntity` pointing to the `Person` entity (required field for `ProfilePage` per schema.org/Google spec)
- Updated snapshot

## Test plan

- [x] Tests pass with updated snapshot
- [ ] Verify Google Search Console clears the error after deploy