### PR TITLE
fix: add descriptive aria-label to Read more links for SEO and a11y

### DIFF
--- a/apps/web/components/LatestPostHero/LatestPostHero.spec.tsx
+++ b/apps/web/components/LatestPostHero/LatestPostHero.spec.tsx
@@ -230,13 +230,14 @@ describe('LatestPostHero', () => {
     expect(screen.queryByRole('time')).toBeNull()
   })
 
-  it('renders the read more link pointing to the post URL', () => {
+  it('renders the read more link pointing to the post URL with accessible label', () => {
     renderWithTheme(
       <LatestPostHero post={mockPost} lng="en" readMoreLabel="Read more →" />,
     )
     const link = screen.getByTestId('latest-post-hero-link')
     expect(link).toHaveAttribute('href', '/en/blog/5/my-post')
     expect(link).toHaveTextContent('Read more →')
+    expect(link).toHaveAttribute('aria-label', 'Read more → My Post Title')
   })
 
   it('falls back to enUS for unknown locale', () => {

--- a/apps/web/components/LatestPostHero/LatestPostHero.tsx
+++ b/apps/web/components/LatestPostHero/LatestPostHero.tsx
@@ -85,7 +85,11 @@ export function LatestPostHero({
             </>
           )}
         </StyledMeta>
-        <StyledReadMoreLink href={url} data-testid="latest-post-hero-link">
+        <StyledReadMoreLink
+          href={url}
+          aria-label={`${readMoreLabel} ${post.title}`}
+          data-testid="latest-post-hero-link"
+        >
           {readMoreLabel}
         </StyledReadMoreLink>
       </StyledContent>

--- a/libs/post-card/src/lib/PostCard.spec.tsx
+++ b/libs/post-card/src/lib/PostCard.spec.tsx
@@ -89,20 +89,19 @@ describe('PostCard', () => {
     expect(screen.getByAltText('Test Post Title')).toBeInTheDocument()
   })
 
-  it('renders read more link with correct href', () => {
+  it('renders read more link with correct href and accessible label', () => {
     renderWithTheme(<PostCard {...defaultProps} />)
-    expect(screen.getByRole('link', { name: 'Read more' })).toHaveAttribute(
-      'href',
-      '/en/blog/1/test-post',
-    )
+    const link = screen.getByRole('link', {
+      name: 'Read more Test Post Title',
+    })
+    expect(link).toHaveAttribute('href', '/en/blog/1/test-post')
   })
 
   it('renders read more link with href="#" when postNumber is undefined', () => {
     renderWithTheme(<PostCard {...defaultProps} postNumber={undefined} />)
-    expect(screen.getByRole('link', { name: 'Read more' })).toHaveAttribute(
-      'href',
-      '#',
-    )
+    expect(
+      screen.getByRole('link', { name: 'Read more Test Post Title' }),
+    ).toHaveAttribute('href', '#')
   })
 
   it('does not render date when publishedAt is null', () => {

--- a/libs/post-card/src/lib/PostCard.tsx
+++ b/libs/post-card/src/lib/PostCard.tsx
@@ -101,7 +101,9 @@ export function PostCard({
             <StyledMoreTags>+{extraTagCount}</StyledMoreTags>
           )}
         </StyledTagList>
-        <StyledReadMore href={href}>{readMoreLabel}</StyledReadMore>
+        <StyledReadMore href={href} aria-label={`${readMoreLabel} ${title}`}>
+          {readMoreLabel}
+        </StyledReadMore>
       </StyledBody>
     </StyledCard>
   )

--- a/libs/post-card/src/lib/__snapshots__/PostCard.spec.tsx.snap
+++ b/libs/post-card/src/lib/__snapshots__/PostCard.spec.tsx.snap
@@ -229,6 +229,7 @@ exports[`PostCard matches snapshot 1`] = `
           </li>
         </ul>
         <a
+          aria-label="Read more Test Post Title"
           class="c11"
           href="/en/blog/1/test-post"
         >
@@ -496,6 +497,7 @@ exports[`PostCard matches snapshot with series badge 1`] = `
           </li>
         </ul>
         <a
+          aria-label="Read more Test Post Title"
           class="c12"
           href="/en/blog/1/test-post"
         >


### PR DESCRIPTION
## Summary

- `PostCard` and `LatestPostHero` "Read more" links had generic link text flagged by SEO tools
- Add `aria-label` to each link combining the label + post title (e.g. `"Read more My Post Title"`)
- Visual display stays "Read more"; accessible name is now unique and descriptive per post

## Test plan

- [ ] Unit tests pass (`yarn test:web`, `yarn test:libs`)
- [ ] SEO audit: "Links do not have descriptive text" warning no longer appears for these links
- [ ] Screen readers announce the full link label including post title

🤖 Generated with [Claude Code](https://claude.com/claude-code)