### PR TITLE
feat: add pagination to admin posts table (20 rows per page)

### DIFF
--- a/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.constants.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.constants.ts
@@ -5,3 +5,5 @@ export const STATUS_FILTERS: StatusFilter[] = [
   'draft',
   'archived',
 ]
+
+export const PAGE_LIMIT = 20

--- a/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.spec.tsx
@@ -13,7 +13,7 @@ const mockPush = jest.fn()
 
 jest.mock('@web/i18n/client', () => ({
   useClientTranslation: jest.fn().mockReturnValue({
-    t: (key: string) => {
+    t: (key: string, vars?: Record<string, unknown>) => {
       const translations: Record<string, string> = {
         'posts.searchPlaceholder': 'Search posts…',
         'posts.table.title': 'Title',
@@ -47,11 +47,20 @@ jest.mock('@web/i18n/client', () => ({
         'posts.archiveDisabledPublished': 'Unpublish the post before archiving',
         'posts.empty': 'No posts found',
         'posts.newPost': 'New post',
+        'posts.pagination.prev': '← Prev',
+        'posts.pagination.next': 'Next →',
+        'posts.pagination.pageOf': '{{page}} of {{total}}',
         refresh: 'Refresh',
         'confirmDelete.confirm': 'Confirm delete',
         'confirmDelete.cancel': 'Cancel delete',
       }
-      return translations[key] ?? key
+      let result = translations[key] ?? key
+      if (vars) {
+        Object.entries(vars).forEach(([k, v]) => {
+          result = result.replace(`{{${k}}}`, String(v))
+        })
+      }
+      return result
     },
   }),
 }))
@@ -972,5 +981,92 @@ describe('PostTable', () => {
     fireEvent.click(screen.getByTestId('confirm-delete-cancel'))
     expect(axios.delete).not.toHaveBeenCalled()
     expect(screen.getByTestId('bulk-actions')).toBeInTheDocument()
+  })
+
+  describe('pagination', () => {
+    const make21Posts = () =>
+      Array.from({ length: 21 }, (_, i) =>
+        makePost({ id: `p${i}`, titleEn: `Post ${i}` }),
+      )
+
+    it('does not render pagination when posts <= 20', () => {
+      renderApp(<PostTable posts={[makePost()]} />)
+      expect(screen.queryByTestId('pagination')).not.toBeInTheDocument()
+    })
+
+    it('renders pagination when posts > 20', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      expect(screen.getByTestId('pagination')).toBeInTheDocument()
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent('1 of 2')
+    })
+
+    it('shows only first 20 rows on page 1', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      expect(screen.getAllByTestId('post-row')).toHaveLength(20)
+      expect(screen.getByText('Post 0')).toBeInTheDocument()
+      expect(screen.queryByText('Post 20')).not.toBeInTheDocument()
+    })
+
+    it('prev button is disabled on first page', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      expect(screen.getByTestId('pagination-prev')).toBeDisabled()
+    })
+
+    it('next button is disabled on last page', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      fireEvent.click(screen.getByTestId('pagination-next'))
+      expect(screen.getByTestId('pagination-next')).toBeDisabled()
+    })
+
+    it('clicking next shows page 2 with remaining rows', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      fireEvent.click(screen.getByTestId('pagination-next'))
+      expect(screen.getAllByTestId('post-row')).toHaveLength(1)
+      expect(screen.getByText('Post 20')).toBeInTheDocument()
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent('2 of 2')
+    })
+
+    it('clicking prev returns to page 1', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      fireEvent.click(screen.getByTestId('pagination-next'))
+      fireEvent.click(screen.getByTestId('pagination-prev'))
+      expect(screen.getAllByTestId('post-row')).toHaveLength(20)
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent('1 of 2')
+    })
+
+    it('changing filter resets to page 1', () => {
+      const posts = [
+        ...Array.from({ length: 21 }, (_, i) =>
+          makePost({ id: `d${i}`, titleEn: `Draft ${i}`, status: 'draft' }),
+        ),
+        makePost({ id: 'p1', titleEn: 'Published', status: 'published' }),
+      ]
+      renderApp(<PostTable posts={posts} />)
+      fireEvent.click(screen.getByTestId('pagination-next'))
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent('2 of 2')
+      fireEvent.click(screen.getByTestId('filter-published'))
+      expect(screen.queryByTestId('pagination')).not.toBeInTheDocument()
+    })
+
+    it('changing search resets to page 1', () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      fireEvent.click(screen.getByTestId('pagination-next'))
+      fireEvent.change(screen.getByTestId('search-input'), {
+        target: { value: 'Post' },
+      })
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent('1 of 2')
+    })
+
+    it('auto-adjusts to last page when current page becomes empty', async () => {
+      renderApp(<PostTable posts={make21Posts()} />)
+      fireEvent.click(screen.getByTestId('pagination-next'))
+      expect(screen.getAllByTestId('post-row')).toHaveLength(1)
+      fireEvent.click(screen.getByTestId('archive-button'))
+      fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+      await waitFor(() =>
+        expect(screen.queryByTestId('pagination')).not.toBeInTheDocument(),
+      )
+      expect(screen.getAllByTestId('post-row')).toHaveLength(20)
+    })
   })
 })

--- a/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.styles.ts
@@ -298,3 +298,37 @@ export const StyledBulkDeleteButton = styled(Button).attrs({
   text-transform: uppercase;
   letter-spacing: 0.1em;
 `
+
+export const StyledPagination = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 1.5rem 0 0.5rem;
+  border-top: 1px solid rgba(251, 251, 251, 0.06);
+  margin-top: 0.5rem;
+`
+
+export const StyledPageButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${({ theme }) => theme.colors.white};
+
+  &:disabled {
+    opacity: 0.2;
+    cursor: not-allowed;
+  }
+`
+
+export const StyledPageInfo = styled.span`
+  font-size: 0.7rem;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.5;
+  letter-spacing: 0.06em;
+  min-width: 6rem;
+  text-align: center;
+`

--- a/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostTable/PostTable.tsx
@@ -9,7 +9,11 @@ import { ConfirmDeleteModal } from '@web/app/admin/(auth)/components/ConfirmDele
 import { useClientTranslation } from '@web/i18n/client'
 import type { AdminPost } from '@web/lib/db/queries/posts'
 
-import { STATUS_FILTERS, type StatusFilter } from './PostTable.constants'
+import {
+  PAGE_LIMIT,
+  STATUS_FILTERS,
+  type StatusFilter,
+} from './PostTable.constants'
 import {
   StyledActions,
   StyledArchiveButton,
@@ -33,6 +37,9 @@ import {
   StyledLangChips,
   StyledLeftGroup,
   StyledNewPostButton,
+  StyledPageButton,
+  StyledPageInfo,
+  StyledPagination,
   StyledPublishButton,
   StyledRefreshButton,
   StyledSearchInput,
@@ -101,6 +108,7 @@ export function PostTable({ posts }: PostTableProps) {
   const [hardDeleteTargetId, setHardDeleteTargetId] = useState<string | null>(
     null,
   )
+  const [page, setPage] = useState(1)
 
   const QUERY_KEY = ['admin-posts'] as const
 
@@ -130,6 +138,13 @@ export function PostTable({ posts }: PostTableProps) {
     const matchesSearch = title.toLowerCase().includes(searchLower)
     return matchesStatus && matchesSearch
   })
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_LIMIT))
+  const effectivePage = Math.min(page, totalPages)
+  const paginated = filtered.slice(
+    (effectivePage - 1) * PAGE_LIMIT,
+    effectivePage * PAGE_LIMIT,
+  )
 
   function handleArchive(e: React.MouseEvent, id: string) {
     e.stopPropagation()
@@ -211,7 +226,7 @@ export function PostTable({ posts }: PostTableProps) {
 
   const canPublish = (post: AdminPost) => !!(post.titleEn && post.titleEs)
 
-  const allVisibleIds = filtered.map((p) => p.id)
+  const allVisibleIds = paginated.map((p) => p.id)
   const allSelected =
     allVisibleIds.length > 0 && allVisibleIds.every((id) => selectedIds.has(id))
   const selectedPosts = filtered.filter((p) => selectedIds.has(p.id))
@@ -353,7 +368,10 @@ export function PostTable({ posts }: PostTableProps) {
             type="search"
             placeholder={t('posts.searchPlaceholder')}
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setPage(1)
+            }}
             data-testid="search-input"
           />
           <StyledFilterTabs data-testid="filter-tabs">
@@ -364,6 +382,7 @@ export function PostTable({ posts }: PostTableProps) {
                 onClick={() => {
                   setFilter(s)
                   setSelectedIds(new Set())
+                  setPage(1)
                   const params = new URLSearchParams(searchParams.toString())
                   if (s === 'all') {
                     params.delete('filter')
@@ -478,7 +497,7 @@ export function PostTable({ posts }: PostTableProps) {
               </StyledTd>
             </tr>
           )}
-          {filtered.map((post) => (
+          {paginated.map((post) => (
             <StyledTr key={post.id} data-testid="post-row">
               <StyledCheckboxTd>
                 <input
@@ -606,6 +625,31 @@ export function PostTable({ posts }: PostTableProps) {
           ))}
         </StyledTbody>
       </StyledTable>
+
+      {totalPages > 1 && (
+        <StyledPagination data-testid="pagination">
+          <StyledPageButton
+            onClick={() => setPage(effectivePage - 1)}
+            disabled={effectivePage === 1}
+            data-testid="pagination-prev"
+          >
+            {t('posts.pagination.prev')}
+          </StyledPageButton>
+          <StyledPageInfo data-testid="pagination-info">
+            {t('posts.pagination.pageOf', {
+              page: effectivePage,
+              total: totalPages,
+            })}
+          </StyledPageInfo>
+          <StyledPageButton
+            onClick={() => setPage(effectivePage + 1)}
+            disabled={effectivePage === totalPages}
+            data-testid="pagination-next"
+          >
+            {t('posts.pagination.next')}
+          </StyledPageButton>
+        </StyledPagination>
+      )}
 
       <ConfirmDeleteModal
         isOpen={archiveTargetId !== null}

--- a/apps/web/i18n/locales/en/admin.json
+++ b/apps/web/i18n/locales/en/admin.json
@@ -55,7 +55,12 @@
     "bulkArchiveConfirm": "Archive selected posts? Only draft posts will be archived. You can restore them later.",
     "bulkUnarchiveConfirm": "Unarchive selected posts? They will be restored as drafts.",
     "bulkDeleteConfirm": "Permanently delete selected posts? This cannot be undone.",
-    "empty": "No posts found"
+    "empty": "No posts found",
+    "pagination": {
+      "prev": "← Prev",
+      "next": "Next →",
+      "pageOf": "{{page}} of {{total}}"
+    }
   },
   "confirmDelete": {
     "confirm": "Confirm",


### PR DESCRIPTION
## Summary

- Max 20 rows per page; excess rows paginated with ← Prev / page info / Next → bar
- Select-all checkbox scoped to current page only
- Page resets to 1 on filter tab or search change
- `effectivePage = Math.min(page, totalPages)` auto-adjusts when a bulk action empties the current page — no `useEffect` needed
- Pagination bar hidden when only 1 page

## Test plan

- [ ] Unit tests pass (`yarn test:web`) — 10 new pagination tests
- [ ] Table with ≤20 posts shows no pagination bar
- [ ] Table with >20 posts shows pagination bar with correct page info
- [ ] Prev/Next navigation works and disables at boundaries
- [ ] Filter and search changes reset to page 1
- [ ] Archiving last item on page 2 auto-returns to page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)