### PR TITLE
chore: address code review findings

### DIFF
--- a/apps/web-e2e/src/e2e/admin-auth.cy.ts
+++ b/apps/web-e2e/src/e2e/admin-auth.cy.ts
@@ -41,6 +41,19 @@ describe('Admin auth — login', () => {
   })
 })
 
+describe('Admin auth — editor role restrictions', () => {
+  beforeEach(() => {
+    loginViaUi()
+    cy.url({ timeout: 20000 }).should('include', '/admin/posts')
+  })
+
+  it('redirects /admin/users to /admin/posts for editor role', () => {
+    cy.visit('/admin/users')
+    cy.url({ timeout: 15000 }).should('include', '/admin/posts')
+    cy.url().should('not.include', '/admin/users')
+  })
+})
+
 describe('Admin auth — logout', () => {
   beforeEach(() => {
     loginViaUi()

--- a/apps/web/app/admin/(auth)/categories/components/CategoriesPageView/CategoriesPageView.styles.ts
+++ b/apps/web/app/admin/(auth)/categories/components/CategoriesPageView/CategoriesPageView.styles.ts
@@ -1,24 +1,13 @@
 import styled from 'styled-components'
 
-export const StyledPage = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 2rem 0;
-`
+import {
+  StyledAdminPage,
+  StyledAdminPageHeader,
+  StyledAdminPageHeading,
+} from '../../../components/AdminPage/AdminPage.styles'
 
-export const StyledHeader = styled.div`
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-`
+export const StyledPage = styled(StyledAdminPage)``
 
-export const StyledHeading = styled.h1`
-  font-size: 0.9rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: ${({ theme }) => theme.colors.white};
-  margin: 0;
-`
+export const StyledHeader = styled(StyledAdminPageHeader)``
+
+export const StyledHeading = styled(StyledAdminPageHeading)``

--- a/apps/web/app/admin/(auth)/categories/components/CategoryForm/CategoryForm.styles.ts
+++ b/apps/web/app/admin/(auth)/categories/components/CategoryForm/CategoryForm.styles.ts
@@ -1,30 +1,27 @@
 import styled from 'styled-components'
 
-import { Button } from '@sdlgr/button'
-import { Input, Textarea } from '@sdlgr/input'
+import { Textarea } from '@sdlgr/input'
 
-export const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  max-width: 480px;
-`
+import {
+  StyledAdminActions,
+  StyledAdminBackLink,
+  StyledAdminError,
+  StyledAdminFieldGroup,
+  StyledAdminForm,
+  StyledAdminFormHeading,
+  StyledAdminInput,
+  StyledAdminLabel,
+  StyledAdminPageHeader,
+  StyledAdminSubmitButton,
+} from '../../../components/AdminForm/AdminForm.styles'
 
-export const StyledFieldGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-`
+export const StyledForm = styled(StyledAdminForm)``
 
-export const StyledLabel = styled.label`
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.5;
-`
+export const StyledFieldGroup = styled(StyledAdminFieldGroup)``
 
-export const StyledInput = styled(Input)`
+export const StyledLabel = styled(StyledAdminLabel)``
+
+export const StyledInput = styled(StyledAdminInput)`
   &[aria-readonly='true'] {
     opacity: 0.4;
     cursor: default;
@@ -42,51 +39,14 @@ export const StyledHelper = styled.p`
   margin: 0;
 `
 
-export const StyledError = styled.p`
-  font-size: 0.7rem;
-  color: ${({ theme }) => theme.colors.orange};
-  margin: 0;
-`
+export const StyledError = styled(StyledAdminError)``
 
-export const StyledActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding-top: 0.5rem;
-`
+export const StyledActions = styled(StyledAdminActions)``
 
-export const StyledSubmitButton = styled(Button).attrs({ variant: 'inverted' })`
-  padding: 0.625rem 1.25rem;
-  font-family: inherit;
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-`
+export const StyledSubmitButton = styled(StyledAdminSubmitButton)``
 
-export const StyledBackLink = styled.a`
-  font-size: 0.7rem;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.45;
-  cursor: pointer;
-  text-decoration: none;
+export const StyledBackLink = styled(StyledAdminBackLink)``
 
-  &:hover {
-    opacity: 0.8;
-  }
-`
+export const StyledPageHeader = styled(StyledAdminPageHeader)``
 
-export const StyledPageHeader = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-  margin-bottom: 2rem;
-`
-
-export const StyledHeading = styled.h1`
-  font-size: 1.25rem;
-  font-weight: 400;
-  margin: 0;
-  color: ${({ theme }) => theme.colors.white};
-`
+export const StyledHeading = styled(StyledAdminFormHeading)``

--- a/apps/web/app/admin/(auth)/categories/components/CategoryTable/CategoryTable.styles.ts
+++ b/apps/web/app/admin/(auth)/categories/components/CategoryTable/CategoryTable.styles.ts
@@ -3,104 +3,57 @@ import styled from 'styled-components'
 import { Button } from '@sdlgr/button'
 import { Input } from '@sdlgr/input'
 
+import {
+  StyledAdminButtonGroup,
+  StyledAdminCancelButton,
+  StyledAdminDeleteButton,
+  StyledAdminEditButton,
+  StyledAdminEmpty,
+  StyledAdminLocaleTab,
+  StyledAdminLocaleTabs,
+  StyledAdminRefreshButton,
+  StyledAdminRowActions,
+  StyledAdminSaveButton,
+  StyledAdminSearchInput,
+  StyledAdminTable,
+  StyledAdminTbody,
+  StyledAdminTd,
+  StyledAdminTh,
+  StyledAdminThead,
+  StyledAdminToolbar,
+  StyledAdminTr,
+} from '../../../components/AdminTable/AdminTable.styles'
+
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0;
 `
 
-export const StyledToolbar = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-  flex-wrap: wrap;
-`
+export const StyledToolbar = styled(StyledAdminToolbar)``
 
-export const StyledSearchInput = styled(Input)`
-  font-size: 0.75rem;
-  width: 220px;
-  padding: 0.375rem 0;
-`
+export const StyledSearchInput = styled(StyledAdminSearchInput)``
 
 export const StyledNewButton = styled(Button)`
   text-transform: uppercase;
   letter-spacing: 0.1em;
 `
 
-export const StyledRefreshButton = styled(Button).attrs({
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+export const StyledRefreshButton = styled(StyledAdminRefreshButton)``
 
-  &:hover {
-    opacity: 0.6;
-  }
-`
+export const StyledButtonGroup = styled(StyledAdminButtonGroup)``
 
-export const StyledButtonGroup = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-`
+export const StyledTable = styled(StyledAdminTable)``
 
-export const StyledTable = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-`
+export const StyledThead = styled(StyledAdminThead)``
 
-export const StyledThead = styled.thead`
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-`
+export const StyledTh = styled(StyledAdminTh)``
 
-export const StyledTh = styled.th`
-  padding: 0.75rem 1rem;
-  text-align: left;
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.4;
-  font-weight: 400;
-  white-space: nowrap;
+export const StyledTbody = styled(StyledAdminTbody)``
 
-  &:first-child {
-    padding-left: 0;
-  }
+export const StyledTr = styled(StyledAdminTr)``
 
-  &:last-child {
-    padding-right: 0;
-    text-align: right;
-  }
-`
-
-export const StyledTbody = styled.tbody``
-
-export const StyledTr = styled.tr`
-  border-bottom: 1px solid rgba(251, 251, 251, 0.06);
-
-  &:last-child {
-    border-bottom: none;
-  }
-`
-
-export const StyledTd = styled.td`
-  padding: 0.875rem 1rem;
-  font-size: 0.75rem;
-  color: ${({ theme }) => theme.colors.white};
-  vertical-align: middle;
-
-  &:first-child {
-    padding-left: 0;
-  }
-
-  &:last-child {
-    padding-right: 0;
-  }
-`
+export const StyledTd = styled(StyledAdminTd)``
 
 export const StyledName = styled.span`
   font-size: 0.8rem;
@@ -124,95 +77,18 @@ export const StyledEditInput = styled(Input)`
   width: 100%;
 `
 
-export const StyledActions = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-`
+export const StyledActions = styled(StyledAdminRowActions)``
 
-export const StyledEditButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-`
+export const StyledEditButton = styled(StyledAdminEditButton)``
 
-export const StyledSaveButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-`
+export const StyledSaveButton = styled(StyledAdminSaveButton)``
 
-export const StyledCancelButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-})`
-  color: ${({ theme }) => theme.colors.white};
-  border-color: rgba(251, 251, 251, 0.3);
-  opacity: 0.6;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+export const StyledCancelButton = styled(StyledAdminCancelButton)``
 
-  &:hover {
-    border-color: ${({ theme }) => theme.colors.white};
-    opacity: 1;
-  }
-`
+export const StyledDeleteButton = styled(StyledAdminDeleteButton)``
 
-export const StyledDeleteButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'danger',
-})`
-  opacity: 0.6;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+export const StyledEmpty = styled(StyledAdminEmpty)``
 
-  &:hover:not(:disabled) {
-    opacity: 1;
-  }
+export const StyledLocaleTabs = styled(StyledAdminLocaleTabs)``
 
-  &:disabled {
-    opacity: 0.3;
-  }
-`
-
-export const StyledEmpty = styled.div`
-  padding: 4rem 0;
-  text-align: center;
-  font-size: 0.75rem;
-  opacity: 0.3;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-`
-
-export const StyledLocaleTabs = styled.div`
-  display: flex;
-  gap: 0.25rem;
-  margin-bottom: 0.375rem;
-`
-
-export const StyledLocaleTab = styled(Button).attrs({ variant: 'label' })`
-  min-height: unset;
-  padding: 0.1rem 0.4rem;
-  font-size: 0.55rem;
-  border-color: ${({ active, theme }) =>
-    active ? theme.colors.green : 'rgba(251,251,251,0.2)'};
-  color: ${({ active, theme }) =>
-    active ? theme.colors.green : theme.colors.white};
-  opacity: ${({ active }) => (active ? 1 : 0.4)};
-
-  &:hover {
-    border-color: ${({ active, theme }) =>
-      active ? theme.colors.green : 'rgba(251,251,251,0.4)'};
-    opacity: 1;
-    color: ${({ active, theme }) =>
-      active ? theme.colors.green : theme.colors.white};
-  }
-`
+export const StyledLocaleTab = styled(StyledAdminLocaleTab)``

--- a/apps/web/app/admin/(auth)/components/AdminForm/AdminForm.styles.ts
+++ b/apps/web/app/admin/(auth)/components/AdminForm/AdminForm.styles.ts
@@ -1,0 +1,78 @@
+import styled from 'styled-components'
+
+import { Button } from '@sdlgr/button'
+import { Input } from '@sdlgr/input'
+
+export const StyledAdminForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 480px;
+`
+
+export const StyledAdminFieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+`
+
+export const StyledAdminLabel = styled.label`
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.5;
+`
+
+export const StyledAdminInput = styled(Input)``
+
+export const StyledAdminError = styled.p`
+  font-size: 0.7rem;
+  color: ${({ theme }) => theme.colors.orange};
+  margin: 0;
+`
+
+export const StyledAdminActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-top: 0.5rem;
+`
+
+export const StyledAdminSubmitButton = styled(Button).attrs({
+  variant: 'inverted',
+})`
+  padding: 0.625rem 1.25rem;
+  font-family: inherit;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+`
+
+export const StyledAdminBackLink = styled.a`
+  font-size: 0.7rem;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.45;
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`
+
+export const StyledAdminPageHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
+  margin-bottom: 2rem;
+`
+
+export const StyledAdminFormHeading = styled.h1`
+  font-size: 1.25rem;
+  font-weight: 400;
+  margin: 0;
+  color: ${({ theme }) => theme.colors.white};
+`

--- a/apps/web/app/admin/(auth)/components/AdminPage/AdminPage.styles.ts
+++ b/apps/web/app/admin/(auth)/components/AdminPage/AdminPage.styles.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+export const StyledAdminPage = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem 0;
+`
+
+export const StyledAdminPageHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+`
+
+export const StyledAdminPageHeading = styled.h1`
+  font-size: 0.9rem;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: ${({ theme }) => theme.colors.white};
+  margin: 0;
+`

--- a/apps/web/app/admin/(auth)/components/AdminTable/AdminTable.styles.ts
+++ b/apps/web/app/admin/(auth)/components/AdminTable/AdminTable.styles.ts
@@ -1,0 +1,187 @@
+import styled from 'styled-components'
+
+import { Button } from '@sdlgr/button'
+import { Input } from '@sdlgr/input'
+
+export const StyledAdminToolbar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
+  flex-wrap: wrap;
+`
+
+export const StyledAdminSearchInput = styled(Input)`
+  font-size: 0.75rem;
+  width: 220px;
+  padding: 0.375rem 0;
+`
+
+export const StyledAdminButtonGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`
+
+export const StyledAdminRefreshButton = styled(Button).attrs({
+  colorScheme: 'success',
+})`
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+
+  &:hover {
+    opacity: 0.6;
+  }
+`
+
+export const StyledAdminTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+`
+
+export const StyledAdminThead = styled.thead`
+  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
+`
+
+export const StyledAdminTh = styled.th`
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.4;
+  font-weight: 400;
+  white-space: nowrap;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:last-child {
+    padding-right: 0;
+    text-align: right;
+  }
+`
+
+export const StyledAdminTbody = styled.tbody``
+
+export const StyledAdminTr = styled.tr`
+  border-bottom: 1px solid rgba(251, 251, 251, 0.06);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`
+
+export const StyledAdminTd = styled.td`
+  padding: 0.875rem 1rem;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.white};
+  vertical-align: middle;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:last-child {
+    padding-right: 0;
+  }
+`
+
+export const StyledAdminRowActions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+`
+
+export const StyledAdminEditButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+  colorScheme: 'success',
+})`
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+`
+
+export const StyledAdminSaveButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+  colorScheme: 'success',
+})`
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+`
+
+export const StyledAdminCancelButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  color: ${({ theme }) => theme.colors.white};
+  border-color: rgba(251, 251, 251, 0.3);
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.white};
+    opacity: 1;
+  }
+`
+
+export const StyledAdminDeleteButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+  colorScheme: 'danger',
+})`
+  font-family: inherit;
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+  }
+
+  &:disabled {
+    opacity: 0.3;
+  }
+`
+
+export const StyledAdminEmpty = styled.div`
+  padding: 4rem 0;
+  text-align: center;
+  font-size: 0.75rem;
+  opacity: 0.3;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+`
+
+export const StyledAdminLocaleTabs = styled.div`
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.375rem;
+`
+
+export const StyledAdminLocaleTab = styled(Button).attrs({ variant: 'label' })`
+  min-height: unset;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.55rem;
+  border-color: ${({ active, theme }) =>
+    active ? theme.colors.green : 'rgba(251,251,251,0.2)'};
+  color: ${({ active, theme }) =>
+    active ? theme.colors.green : theme.colors.white};
+  opacity: ${({ active }) => (active ? 1 : 0.4)};
+
+  &:hover {
+    border-color: ${({ active, theme }) =>
+      active ? theme.colors.green : 'rgba(251,251,251,0.4)'};
+    opacity: 1;
+    color: ${({ active, theme }) =>
+      active ? theme.colors.green : theme.colors.white};
+  }
+`

--- a/apps/web/app/admin/(auth)/posts/components/PostsPageView/PostsPageView.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostsPageView/PostsPageView.styles.ts
@@ -1,24 +1,13 @@
 import styled from 'styled-components'
 
-export const StyledPage = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 2rem 0;
-`
+import {
+  StyledAdminPage,
+  StyledAdminPageHeader,
+  StyledAdminPageHeading,
+} from '../../../components/AdminPage/AdminPage.styles'
 
-export const StyledHeader = styled.div`
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-`
+export const StyledPage = styled(StyledAdminPage)``
 
-export const StyledHeading = styled.h1`
-  font-size: 0.9rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: ${({ theme }) => theme.colors.white};
-  margin: 0;
-`
+export const StyledHeader = styled(StyledAdminPageHeader)``
+
+export const StyledHeading = styled(StyledAdminPageHeading)``

--- a/apps/web/app/admin/(auth)/series/components/SeriesForm/SeriesForm.styles.ts
+++ b/apps/web/app/admin/(auth)/series/components/SeriesForm/SeriesForm.styles.ts
@@ -1,30 +1,25 @@
 import styled from 'styled-components'
 
-import { Button } from '@sdlgr/button'
-import { Input } from '@sdlgr/input'
+import {
+  StyledAdminActions,
+  StyledAdminBackLink,
+  StyledAdminError,
+  StyledAdminFieldGroup,
+  StyledAdminForm,
+  StyledAdminFormHeading,
+  StyledAdminInput,
+  StyledAdminLabel,
+  StyledAdminPageHeader,
+  StyledAdminSubmitButton,
+} from '../../../components/AdminForm/AdminForm.styles'
 
-export const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  max-width: 480px;
-`
+export const StyledForm = styled(StyledAdminForm)``
 
-export const StyledFieldGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
+export const StyledFieldGroup = styled(StyledAdminFieldGroup)``
 
-  label {
-    font-size: 0.6rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: ${({ theme }) => theme.colors.white};
-    opacity: 0.5;
-  }
-`
+export const StyledLabel = styled(StyledAdminLabel)``
 
-export const StyledInput = styled(Input)``
+export const StyledInput = styled(StyledAdminInput)``
 
 export const StyledHelper = styled.p`
   font-size: 0.65rem;
@@ -32,51 +27,14 @@ export const StyledHelper = styled.p`
   margin: 0;
 `
 
-export const StyledError = styled.p`
-  font-size: 0.7rem;
-  color: ${({ theme }) => theme.colors.orange};
-  margin: 0;
-`
+export const StyledError = styled(StyledAdminError)``
 
-export const StyledActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding-top: 0.5rem;
-`
+export const StyledActions = styled(StyledAdminActions)``
 
-export const StyledSubmitButton = styled(Button).attrs({ variant: 'inverted' })`
-  padding: 0.625rem 1.25rem;
-  font-family: inherit;
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-`
+export const StyledSubmitButton = styled(StyledAdminSubmitButton)``
 
-export const StyledBackLink = styled.a`
-  font-size: 0.7rem;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.45;
-  cursor: pointer;
-  text-decoration: none;
+export const StyledBackLink = styled(StyledAdminBackLink)``
 
-  &:hover {
-    opacity: 0.8;
-  }
-`
+export const StyledPageHeader = styled(StyledAdminPageHeader)``
 
-export const StyledPageHeader = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-  margin-bottom: 2rem;
-`
-
-export const StyledHeading = styled.h1`
-  font-size: 1.25rem;
-  font-weight: 400;
-  margin: 0;
-  color: ${({ theme }) => theme.colors.white};
-`
+export const StyledHeading = styled(StyledAdminFormHeading)``

--- a/apps/web/app/admin/(auth)/series/components/SeriesPageView/SeriesPageView.styles.ts
+++ b/apps/web/app/admin/(auth)/series/components/SeriesPageView/SeriesPageView.styles.ts
@@ -1,24 +1,13 @@
 import styled from 'styled-components'
 
-export const StyledPage = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 2rem 0;
-`
+import {
+  StyledAdminPage,
+  StyledAdminPageHeader,
+  StyledAdminPageHeading,
+} from '../../../components/AdminPage/AdminPage.styles'
 
-export const StyledHeader = styled.div`
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-`
+export const StyledPage = styled(StyledAdminPage)``
 
-export const StyledHeading = styled.h1`
-  font-size: 0.9rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: ${({ theme }) => theme.colors.white};
-  margin: 0;
-`
+export const StyledHeader = styled(StyledAdminPageHeader)``
+
+export const StyledHeading = styled(StyledAdminPageHeading)``

--- a/apps/web/app/admin/(auth)/series/components/SeriesTable/SeriesTable.styles.ts
+++ b/apps/web/app/admin/(auth)/series/components/SeriesTable/SeriesTable.styles.ts
@@ -3,99 +3,52 @@ import styled from 'styled-components'
 import { Button } from '@sdlgr/button'
 import { Input } from '@sdlgr/input'
 
+import {
+  StyledAdminButtonGroup,
+  StyledAdminCancelButton,
+  StyledAdminDeleteButton,
+  StyledAdminEditButton,
+  StyledAdminEmpty,
+  StyledAdminLocaleTab,
+  StyledAdminLocaleTabs,
+  StyledAdminRefreshButton,
+  StyledAdminRowActions,
+  StyledAdminSaveButton,
+  StyledAdminSearchInput,
+  StyledAdminTable,
+  StyledAdminTbody,
+  StyledAdminTd,
+  StyledAdminTh,
+  StyledAdminThead,
+  StyledAdminToolbar,
+  StyledAdminTr,
+} from '../../../components/AdminTable/AdminTable.styles'
+
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0;
 `
 
-export const StyledToolbar = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-  flex-wrap: wrap;
-`
+export const StyledToolbar = styled(StyledAdminToolbar)``
 
-export const StyledSearchInput = styled(Input)`
-  font-size: 0.75rem;
-  width: 220px;
-  padding: 0.375rem 0;
-`
+export const StyledSearchInput = styled(StyledAdminSearchInput)``
 
-export const StyledRefreshButton = styled(Button).attrs({
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+export const StyledRefreshButton = styled(StyledAdminRefreshButton)``
 
-  &:hover {
-    opacity: 0.6;
-  }
-`
+export const StyledButtonGroup = styled(StyledAdminButtonGroup)``
 
-export const StyledButtonGroup = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-`
+export const StyledTable = styled(StyledAdminTable)``
 
-export const StyledTable = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-`
+export const StyledThead = styled(StyledAdminThead)``
 
-export const StyledThead = styled.thead`
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-`
+export const StyledTh = styled(StyledAdminTh)``
 
-export const StyledTh = styled.th`
-  padding: 0.75rem 1rem;
-  text-align: left;
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.4;
-  font-weight: 400;
-  white-space: nowrap;
+export const StyledTbody = styled(StyledAdminTbody)``
 
-  &:first-child {
-    padding-left: 0;
-  }
+export const StyledTr = styled(StyledAdminTr)``
 
-  &:last-child {
-    padding-right: 0;
-    text-align: right;
-  }
-`
-
-export const StyledTbody = styled.tbody``
-
-export const StyledTr = styled.tr`
-  border-bottom: 1px solid rgba(251, 251, 251, 0.06);
-
-  &:last-child {
-    border-bottom: none;
-  }
-`
-
-export const StyledTd = styled.td`
-  padding: 0.875rem 1rem;
-  font-size: 0.75rem;
-  color: ${({ theme }) => theme.colors.white};
-  vertical-align: middle;
-
-  &:first-child {
-    padding-left: 0;
-  }
-
-  &:last-child {
-    padding-right: 0;
-  }
-`
+export const StyledTd = styled(StyledAdminTd)``
 
 export const StyledSeriesId = styled.span`
   font-size: 0.7rem;
@@ -240,100 +193,23 @@ export const StyledEditInput = styled(Input)`
   width: 100%;
 `
 
-export const StyledActions = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-`
+export const StyledActions = styled(StyledAdminRowActions)``
 
 export const StyledNewButton = styled(Button)`
   text-transform: uppercase;
   letter-spacing: 0.1em;
 `
 
-export const StyledEditButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-`
+export const StyledEditButton = styled(StyledAdminEditButton)``
 
-export const StyledSaveButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-`
+export const StyledSaveButton = styled(StyledAdminSaveButton)``
 
-export const StyledCancelButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-})`
-  color: ${({ theme }) => theme.colors.white};
-  border-color: rgba(251, 251, 251, 0.3);
-  opacity: 0.6;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+export const StyledCancelButton = styled(StyledAdminCancelButton)``
 
-  &:hover {
-    border-color: ${({ theme }) => theme.colors.white};
-    opacity: 1;
-  }
-`
+export const StyledDeleteButton = styled(StyledAdminDeleteButton)``
 
-export const StyledDeleteButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'danger',
-})`
-  opacity: 0.6;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+export const StyledEmpty = styled(StyledAdminEmpty)``
 
-  &:hover:not(:disabled) {
-    opacity: 1;
-  }
+export const StyledLocaleTabs = styled(StyledAdminLocaleTabs)``
 
-  &:disabled {
-    opacity: 0.3;
-  }
-`
-
-export const StyledEmpty = styled.div`
-  padding: 4rem 0;
-  text-align: center;
-  font-size: 0.75rem;
-  opacity: 0.3;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-`
-
-export const StyledLocaleTabs = styled.div`
-  display: flex;
-  gap: 0.25rem;
-  margin-bottom: 0.375rem;
-`
-
-export const StyledLocaleTab = styled(Button).attrs({ variant: 'label' })`
-  min-height: unset;
-  padding: 0.1rem 0.4rem;
-  font-size: 0.55rem;
-  border-color: ${({ active, theme }) =>
-    active ? theme.colors.green : 'rgba(251,251,251,0.2)'};
-  color: ${({ active, theme }) =>
-    active ? theme.colors.green : theme.colors.white};
-  opacity: ${({ active }) => (active ? 1 : 0.4)};
-
-  &:hover {
-    border-color: ${({ active, theme }) =>
-      active ? theme.colors.green : 'rgba(251,251,251,0.4)'};
-    opacity: 1;
-    color: ${({ active, theme }) =>
-      active ? theme.colors.green : theme.colors.white};
-  }
-`
+export const StyledLocaleTab = styled(StyledAdminLocaleTab)``

--- a/apps/web/app/admin/(auth)/users/components/UserForm/UserForm.styles.ts
+++ b/apps/web/app/admin/(auth)/users/components/UserForm/UserForm.styles.ts
@@ -1,20 +1,20 @@
 import styled from 'styled-components'
 
-import { Button } from '@sdlgr/button'
-import { Input } from '@sdlgr/input'
+import {
+  StyledAdminActions,
+  StyledAdminBackLink,
+  StyledAdminError,
+  StyledAdminFieldGroup,
+  StyledAdminForm,
+  StyledAdminFormHeading,
+  StyledAdminInput,
+  StyledAdminPageHeader,
+  StyledAdminSubmitButton,
+} from '../../../components/AdminForm/AdminForm.styles'
 
-export const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  max-width: 480px;
-`
+export const StyledForm = styled(StyledAdminForm)``
 
-export const StyledFieldGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-
+export const StyledFieldGroup = styled(StyledAdminFieldGroup)`
   label {
     font-size: 0.6rem;
     text-transform: uppercase;
@@ -24,53 +24,16 @@ export const StyledFieldGroup = styled.div`
   }
 `
 
-export const StyledInput = styled(Input)``
+export const StyledInput = styled(StyledAdminInput)``
 
-export const StyledError = styled.p`
-  font-size: 0.7rem;
-  color: ${({ theme }) => theme.colors.orange};
-  margin: 0;
-`
+export const StyledError = styled(StyledAdminError)``
 
-export const StyledActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding-top: 0.5rem;
-`
+export const StyledActions = styled(StyledAdminActions)``
 
-export const StyledSubmitButton = styled(Button).attrs({ variant: 'inverted' })`
-  padding: 0.625rem 1.25rem;
-  font-family: inherit;
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-`
+export const StyledSubmitButton = styled(StyledAdminSubmitButton)``
 
-export const StyledBackLink = styled.a`
-  font-size: 0.7rem;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.45;
-  cursor: pointer;
-  text-decoration: none;
+export const StyledBackLink = styled(StyledAdminBackLink)``
 
-  &:hover {
-    opacity: 0.8;
-  }
-`
+export const StyledPageHeader = styled(StyledAdminPageHeader)``
 
-export const StyledPageHeader = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-  margin-bottom: 2rem;
-`
-
-export const StyledHeading = styled.h1`
-  font-size: 1.25rem;
-  font-weight: 400;
-  margin: 0;
-  color: ${({ theme }) => theme.colors.white};
-`
+export const StyledHeading = styled(StyledAdminFormHeading)``

--- a/apps/web/app/admin/(auth)/users/components/UsersPageView/UsersPageView.styles.ts
+++ b/apps/web/app/admin/(auth)/users/components/UsersPageView/UsersPageView.styles.ts
@@ -1,21 +1,32 @@
 import styled from 'styled-components'
 
 import { Button } from '@sdlgr/button'
-import { Input } from '@sdlgr/input'
 
-export const StyledPage = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 2rem 0;
-`
+import {
+  StyledAdminPage,
+  StyledAdminPageHeader,
+  StyledAdminPageHeading,
+} from '../../../components/AdminPage/AdminPage.styles'
+import {
+  StyledAdminButtonGroup,
+  StyledAdminDeleteButton,
+  StyledAdminEditButton,
+  StyledAdminEmpty,
+  StyledAdminRefreshButton,
+  StyledAdminRowActions,
+  StyledAdminSearchInput,
+  StyledAdminTable,
+  StyledAdminTbody,
+  StyledAdminTd,
+  StyledAdminTh,
+  StyledAdminThead,
+  StyledAdminToolbar,
+  StyledAdminTr,
+} from '../../../components/AdminTable/AdminTable.styles'
 
-export const StyledHeader = styled.div`
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-`
+export const StyledPage = styled(StyledAdminPage)``
+
+export const StyledHeader = styled(StyledAdminPageHeader)``
 
 export const StyledContent = styled.div`
   display: flex;
@@ -23,107 +34,32 @@ export const StyledContent = styled.div`
   gap: 0;
 `
 
-export const StyledToolbar = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-  flex-wrap: wrap;
-`
+export const StyledToolbar = styled(StyledAdminToolbar)``
 
-export const StyledHeading = styled.h1`
-  font-size: 0.9rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: ${({ theme }) => theme.colors.white};
-  margin: 0;
-`
+export const StyledHeading = styled(StyledAdminPageHeading)``
 
-export const StyledSearchInput = styled(Input)`
-  font-size: 0.75rem;
-  width: 220px;
-  padding: 0.375rem 0;
-`
+export const StyledSearchInput = styled(StyledAdminSearchInput)``
 
-export const StyledButtonGroup = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-`
+export const StyledButtonGroup = styled(StyledAdminButtonGroup)``
 
-export const StyledRefreshButton = styled(Button).attrs({
-  colorScheme: 'success',
-})`
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-
-  &:hover {
-    opacity: 0.6;
-  }
-`
+export const StyledRefreshButton = styled(StyledAdminRefreshButton)``
 
 export const StyledNewUserButton = styled(Button)`
   text-transform: uppercase;
   letter-spacing: 0.1em;
 `
 
-export const StyledTable = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-`
+export const StyledTable = styled(StyledAdminTable)``
 
-export const StyledThead = styled.thead`
-  border-bottom: 1px solid rgba(251, 251, 251, 0.08);
-`
+export const StyledThead = styled(StyledAdminThead)``
 
-export const StyledTh = styled.th`
-  padding: 0.75rem 1rem;
-  text-align: left;
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: ${({ theme }) => theme.colors.white};
-  opacity: 0.4;
-  font-weight: 400;
-  white-space: nowrap;
+export const StyledTh = styled(StyledAdminTh)``
 
-  &:first-child {
-    padding-left: 0;
-  }
+export const StyledTbody = styled(StyledAdminTbody)``
 
-  &:last-child {
-    padding-right: 0;
-    text-align: right;
-  }
-`
+export const StyledTr = styled(StyledAdminTr)``
 
-export const StyledTbody = styled.tbody``
-
-export const StyledTr = styled.tr`
-  border-bottom: 1px solid rgba(251, 251, 251, 0.06);
-
-  &:last-child {
-    border-bottom: none;
-  }
-`
-
-export const StyledTd = styled.td`
-  padding: 0.875rem 1rem;
-  font-size: 0.75rem;
-  color: ${({ theme }) => theme.colors.white};
-  vertical-align: middle;
-
-  &:first-child {
-    padding-left: 0;
-  }
-
-  &:last-child {
-    padding-right: 0;
-  }
-`
+export const StyledTd = styled(StyledAdminTd)``
 
 export const StyledRoleBadge = styled.span<{ $role: string }>`
   display: inline-block;
@@ -141,32 +77,11 @@ export const StyledRoleBadge = styled.span<{ $role: string }>`
         : 'rgba(251,251,251,0.1)'};
 `
 
-export const StyledActions = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-`
+export const StyledActions = styled(StyledAdminRowActions)``
 
-export const StyledDeleteButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'danger',
-})`
-  font-family: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-`
+export const StyledDeleteButton = styled(StyledAdminDeleteButton)``
 
-export const StyledEditButton = styled(Button).attrs({
-  variant: 'ghost',
-  size: 'xs',
-  colorScheme: 'success',
-})`
-  font-family: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-`
+export const StyledEditButton = styled(StyledAdminEditButton)``
 
 export const StyledRoleSelectWrapper = styled.div`
   width: 90px;
@@ -186,11 +101,4 @@ export const StyledRoleSelectWrapper = styled.div`
   }
 `
 
-export const StyledEmpty = styled.div`
-  padding: 4rem 0;
-  text-align: center;
-  font-size: 0.75rem;
-  opacity: 0.3;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-`
+export const StyledEmpty = styled(StyledAdminEmpty)``

--- a/apps/web/app/api/categories/[slug]/route.spec.ts
+++ b/apps/web/app/api/categories/[slug]/route.spec.ts
@@ -17,7 +17,14 @@ jest.mock('@web/lib/db/queries/categories', () => ({
 jest.mock('@web/lib/db/queries/posts', () => ({
   getPublishedPostCountByCategory: mockGetPublishedPostCountByCategory,
 }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 
 const { DELETE, PUT } = require('./route') as typeof import('./route')
 

--- a/apps/web/app/api/categories/[slug]/route.ts
+++ b/apps/web/app/api/categories/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAuthRequest, requireAuth } from '@web/lib/api/parseRequest'
 import {
   deleteCategory,
   getCategoryBySlug,
@@ -24,24 +24,14 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const result = await parseAuthRequest(request, updateTranslationSchema)
+  if (!result.ok) return result.response
 
   const { slug } = await params
-
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = updateTranslationSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
+  logger.debug(
+    { slug, locale: result.data.locale },
+    'PUT /api/categories/[slug]',
+  )
 
   try {
     const existing = await getCategoryBySlug(slug)
@@ -49,7 +39,7 @@ export async function PUT(
       return NextResponse.json({ error: 'Category not found' }, { status: 404 })
     }
 
-    const { locale, name, description, slug: localeSlug } = parsed.data
+    const { locale, name, description, slug: localeSlug } = result.data
 
     const translation = await upsertCategoryTranslation({
       categorySlug: slug,
@@ -59,6 +49,7 @@ export async function PUT(
       slug: localeSlug ?? slug,
     })
 
+    logger.info({ slug, locale }, 'PUT /api/categories/[slug]: updated')
     return NextResponse.json(translation)
   } catch (err) {
     logger.error(err, 'Failed to update category')
@@ -73,12 +64,11 @@ export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   const { slug } = await params
+  logger.debug({ slug }, 'DELETE /api/categories/[slug]')
 
   try {
     const publishedCount = await getPublishedPostCountByCategory(slug)
@@ -92,6 +82,7 @@ export async function DELETE(
     }
 
     await deleteCategory(slug)
+    logger.info({ slug }, 'DELETE /api/categories/[slug]: deleted')
     return new NextResponse(null, { status: 204 })
   } catch (err) {
     logger.error(err, 'Failed to delete category')

--- a/apps/web/app/api/categories/route.spec.ts
+++ b/apps/web/app/api/categories/route.spec.ts
@@ -17,7 +17,14 @@ jest.mock('@web/lib/db/queries/categories', () => ({
   createCategory: mockCreateCategory,
   createCategoryTranslation: mockCreateCategoryTranslation,
 }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 
 const { GET, POST } = require('./route') as {
   GET: (req: Request) => Promise<Response>

--- a/apps/web/app/api/categories/route.ts
+++ b/apps/web/app/api/categories/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAuthRequest, requireAuth } from '@web/lib/api/parseRequest'
 import {
   createCategory,
   createCategoryTranslation,
@@ -19,11 +19,11 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
 
   if (searchParams.get('admin') === '1') {
-    const session = await auth()
-    if (!session)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const authResult = await requireAuth()
+    if (!authResult.ok) return authResult.response
     try {
       const categories = await getCategoriesForAdmin()
+      logger.debug({ count: categories.length }, 'GET /api/categories admin')
       return NextResponse.json({ data: categories })
     } catch (err) {
       logger.error(err, 'Failed to get categories')
@@ -36,6 +36,7 @@ export async function GET(request: Request) {
 
   try {
     const categories = await getCategories()
+    logger.debug({ count: categories.length }, 'GET /api/categories')
     return NextResponse.json({ data: categories }, { headers: CACHE_HEADERS })
   } catch (err) {
     logger.error(err, 'Failed to get categories')
@@ -62,25 +63,13 @@ const createCategorySchema = z.object({
 })
 
 export async function POST(request: Request) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const result = await parseAuthRequest(request, createCategorySchema)
+  if (!result.ok) return result.response
 
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = createCategorySchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const { translations } = parsed.data
+  const { translations } = result.data
   const canonicalSlug = translations.en.slug
+
+  logger.debug({ slug: canonicalSlug }, 'POST /api/categories')
 
   try {
     const existing = await getCategoryBySlug(canonicalSlug)
@@ -111,6 +100,7 @@ export async function POST(request: Request) {
       })
     }
 
+    logger.info({ slug: canonicalSlug }, 'POST /api/categories: created')
     return NextResponse.json(category, { status: 201 })
   } catch (err) {
     logger.error(err, 'Failed to create category')

--- a/apps/web/app/api/cron/publish/route.spec.ts
+++ b/apps/web/app/api/cron/publish/route.spec.ts
@@ -15,7 +15,14 @@ jest.mock('next/cache', () => ({
   revalidateTag: mockRevalidateTag,
 }))
 
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 
 const { GET } = require('./route') as {
   GET: (req: Request) => Promise<Response>

--- a/apps/web/app/api/images/[...publicId]/route.spec.ts
+++ b/apps/web/app/api/images/[...publicId]/route.spec.ts
@@ -9,7 +9,14 @@ jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/cloudinary/images', () => ({
   destroyImage: mockDestroyImage,
 }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 
 const { DELETE } = require('./route') as {
   DELETE: (

--- a/apps/web/app/api/images/[...publicId]/route.ts
+++ b/apps/web/app/api/images/[...publicId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { auth } from '@web/lib/auth/config'
+import { requireAuth } from '@web/lib/api/parseRequest'
 import { destroyImage } from '@web/lib/cloudinary/images'
 import { logger } from '@web/lib/logger'
 
@@ -8,13 +8,12 @@ export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ publicId: string[] }> },
 ) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   const { publicId: segments } = await params
   const publicId = segments.join('/')
+  logger.debug({ publicId }, 'DELETE /api/images/[publicId]')
   try {
     await destroyImage(publicId)
   } catch (err) {
@@ -24,5 +23,6 @@ export async function DELETE(
       { status: 500 },
     )
   }
+  logger.info({ publicId }, 'DELETE /api/images/[publicId]: deleted')
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/app/api/images/route.spec.ts
+++ b/apps/web/app/api/images/route.spec.ts
@@ -13,7 +13,14 @@ jest.mock('@web/lib/cloudinary/images', () => ({
   listImages: mockListImages,
   renameImage: mockRenameImage,
 }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 
 const { GET, PATCH } = require('./route') as {
   GET: (request: NextRequest) => Promise<Response>

--- a/apps/web/app/api/images/route.ts
+++ b/apps/web/app/api/images/route.ts
@@ -1,18 +1,17 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
-import { auth } from '@web/lib/auth/config'
+import { requireAuth } from '@web/lib/api/parseRequest'
 import { listImages, renameImage } from '@web/lib/cloudinary/images'
 import { logger } from '@web/lib/logger'
 
 export async function GET(request: NextRequest) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   try {
     const cursor = request.nextUrl.searchParams.get('cursor') ?? undefined
     const { images, nextCursor } = await listImages(cursor)
+    logger.debug({ count: images.length }, 'GET /api/images')
     return NextResponse.json(
       { images, ...(nextCursor ? { nextCursor } : {}) },
       { status: 200 },
@@ -27,10 +26,8 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PATCH(request: NextRequest) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   const body = (await request.json()) as { publicId?: string; newName?: string }
   const { publicId, newName } = body
@@ -44,6 +41,7 @@ export async function PATCH(request: NextRequest) {
 
   try {
     const image = await renameImage(publicId, newName)
+    logger.info({ publicId, newName }, 'PATCH /api/images: renamed')
     return NextResponse.json(image, { status: 200 })
   } catch (err) {
     logger.error(err, 'Failed to rename image')

--- a/apps/web/app/api/posts/[id]/route.spec.ts
+++ b/apps/web/app/api/posts/[id]/route.spec.ts
@@ -20,7 +20,14 @@ const mockLoggerError = jest.fn()
 
 jest.mock('next/cache', () => ({ revalidateTag: mockRevalidateTag }))
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 jest.mock('@web/lib/db/queries/categories', () => ({
   getCategoryBySlug: mockGetCategoryBySlug,
 }))

--- a/apps/web/app/api/posts/[id]/route.ts
+++ b/apps/web/app/api/posts/[id]/route.ts
@@ -2,7 +2,7 @@ import { revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAuthRequest, requireAuth } from '@web/lib/api/parseRequest'
 import { getCategoryBySlug } from '@web/lib/db/queries/categories'
 import {
   getPostById,
@@ -97,26 +97,12 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const result = await parseAuthRequest(request, updatePostSchema)
+  if (!result.ok) return result.response
 
   const { id } = await params
-
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = updatePostSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const data = parsed.data
+  const data = result.data
+  logger.debug({ id, status: data.status }, 'PUT /api/posts/[id]')
 
   if (data.category !== undefined) {
     const category = await getCategoryBySlug(data.category)
@@ -227,6 +213,7 @@ export async function PUT(
       }
     }
 
+    logger.info({ id, status: data.status }, 'PUT /api/posts/[id]: updated')
     revalidateTag('posts', 'default')
     revalidateTag(`post-${id}`, 'default')
     return NextResponse.json(post)
@@ -243,14 +230,13 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   const { id } = await params
   const { searchParams } = new URL(request.url)
   const hard = searchParams.get('hard') === 'true'
+  logger.debug({ id, hard }, 'DELETE /api/posts/[id]')
 
   try {
     const status = await getPostStatus(id)
@@ -263,6 +249,7 @@ export async function DELETE(
         )
       }
       await hardDeletePost(id)
+      logger.info({ id }, 'DELETE /api/posts/[id]: hard deleted')
       revalidateTag('posts', 'default')
       revalidateTag(`post-${id}`, 'default')
       return new NextResponse(null, { status: 204 })
@@ -276,6 +263,7 @@ export async function DELETE(
     }
 
     await softDeletePost(id)
+    logger.info({ id }, 'DELETE /api/posts/[id]: soft deleted')
     revalidateTag('posts', 'default')
     revalidateTag(`post-${id}`, 'default')
     return new NextResponse(null, { status: 204 })

--- a/apps/web/app/api/posts/route.spec.ts
+++ b/apps/web/app/api/posts/route.spec.ts
@@ -16,7 +16,14 @@ const mockLoggerError = jest.fn()
 
 jest.mock('next/cache', () => ({ revalidateTag: mockRevalidateTag }))
 jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 jest.mock('@web/lib/db/queries/categories', () => ({
   getCategoryBySlug: mockGetCategoryBySlug,
 }))

--- a/apps/web/app/api/posts/route.ts
+++ b/apps/web/app/api/posts/route.ts
@@ -2,7 +2,7 @@ import { revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAuthRequest, requireAuth } from '@web/lib/api/parseRequest'
 import { getCategoryBySlug } from '@web/lib/db/queries/categories'
 import {
   createPost,
@@ -35,11 +35,11 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
 
   if (searchParams.get('status') === 'all') {
-    const session = await auth()
-    if (!session)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const authResult = await requireAuth()
+    if (!authResult.ok) return authResult.response
     try {
       const posts = await getAllPosts()
+      logger.debug({ count: posts.length }, 'GET /api/posts admin')
       return NextResponse.json({ data: posts })
     } catch (err) {
       logger.error(err, 'Failed to get all posts')
@@ -125,24 +125,14 @@ const createPostSchema = z.object({
 })
 
 export async function POST(request: Request) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const result = await parseAuthRequest(request, createPostSchema)
+  if (!result.ok) return result.response
 
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = createPostSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const data = parsed.data
+  const data = result.data
+  logger.debug(
+    { category: data.category, status: data.status },
+    'POST /api/posts',
+  )
 
   const category = await getCategoryBySlug(data.category)
   if (!category) {
@@ -220,6 +210,10 @@ export async function POST(request: Request) {
       }
     }
 
+    logger.info(
+      { id: post.id, category: data.category },
+      'POST /api/posts: created',
+    )
     revalidateTag('posts', 'default')
     return NextResponse.json(post, { status: 201 })
   } catch (err) {

--- a/apps/web/app/api/series/[id]/posts/route.spec.ts
+++ b/apps/web/app/api/series/[id]/posts/route.spec.ts
@@ -12,7 +12,12 @@ jest.mock('@web/lib/db/queries/series', () => ({
   getPostsForSeries: (...args: unknown[]) => mockGetPostsForSeries(...args),
 }))
 jest.mock('@web/lib/logger', () => ({
-  logger: { error: (...args: unknown[]) => mockLoggerError(...args) },
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
 }))
 
 function makeParams(id: string) {

--- a/apps/web/app/api/series/[id]/posts/route.ts
+++ b/apps/web/app/api/series/[id]/posts/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { auth } from '@web/lib/auth/config'
+import { requireAuth } from '@web/lib/api/parseRequest'
 import { getPostsForSeries } from '@web/lib/db/queries/series'
 import { logger } from '@web/lib/logger'
 
@@ -8,14 +8,14 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   const { id } = await params
 
   try {
     const posts = await getPostsForSeries(id)
+    logger.debug({ id, count: posts.length }, 'GET /api/series/[id]/posts')
     return NextResponse.json({ data: posts })
   } catch (err) {
     logger.error(err, 'Failed to get posts for series')

--- a/apps/web/app/api/series/[id]/route.spec.ts
+++ b/apps/web/app/api/series/[id]/route.spec.ts
@@ -15,7 +15,12 @@ jest.mock('@web/lib/db/queries/series', () => ({
     mockUpsertSeriesTranslation(...args),
 }))
 jest.mock('@web/lib/logger', () => ({
-  logger: { error: (...args: unknown[]) => mockLoggerError(...args) },
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
 }))
 
 function makeChain(resolved: unknown) {

--- a/apps/web/app/api/series/[id]/route.ts
+++ b/apps/web/app/api/series/[id]/route.ts
@@ -2,7 +2,7 @@ import { and, eq, isNotNull, isNull } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAuthRequest, requireAuth } from '@web/lib/api/parseRequest'
 import { db } from '@web/lib/db'
 import { upsertSeriesTranslation } from '@web/lib/db/queries/series'
 import { posts, series, seriesTranslations } from '@web/lib/db/schema'
@@ -17,28 +17,16 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const result = await parseAuthRequest(request, updateSchema)
+  if (!result.ok) return result.response
 
   const { id } = await params
-
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = updateSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const { locale, title } = parsed.data
+  const { locale, title } = result.data
+  logger.debug({ id, locale }, 'PUT /api/series/[id]')
 
   try {
     await upsertSeriesTranslation(id, locale, title)
+    logger.info({ id, locale }, 'PUT /api/series/[id]: updated')
     return NextResponse.json({ id, locale, title })
   } catch (err) {
     logger.error(err, 'Failed to update series')
@@ -53,11 +41,11 @@ export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   const { id } = await params
+  logger.debug({ id }, 'DELETE /api/series/[id]')
 
   try {
     const linked = await db
@@ -84,6 +72,7 @@ export async function DELETE(
       .where(eq(seriesTranslations.seriesId, id))
     await db.delete(series).where(eq(series.id, id))
 
+    logger.info({ id }, 'DELETE /api/series/[id]: deleted')
     return NextResponse.json({ id })
   } catch (err) {
     logger.error(err, 'Failed to delete series')

--- a/apps/web/app/api/series/route.spec.ts
+++ b/apps/web/app/api/series/route.spec.ts
@@ -17,7 +17,12 @@ jest.mock('@web/lib/db/queries/series', () => ({
     mockUpsertSeriesTranslation(...args),
 }))
 jest.mock('@web/lib/logger', () => ({
-  logger: { error: (...args: unknown[]) => mockLoggerError(...args) },
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
 }))
 
 function makeChain(resolved: unknown) {

--- a/apps/web/app/api/series/route.ts
+++ b/apps/web/app/api/series/route.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAuthRequest, requireAuth } from '@web/lib/api/parseRequest'
 import { db } from '@web/lib/db'
 import {
   getSeriesForAdmin,
@@ -12,12 +12,12 @@ import { series } from '@web/lib/db/schema'
 import { logger } from '@web/lib/logger'
 
 export async function GET() {
-  const session = await auth()
-  if (!session)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   try {
     const data = await getSeriesForAdmin()
+    logger.debug({ count: data.length }, 'GET /api/series')
     return NextResponse.json({ data })
   } catch (err) {
     logger.error(err, 'Failed to get series')
@@ -42,23 +42,11 @@ const createSeriesSchema = z.object({
 })
 
 export async function POST(request: Request) {
-  const session = await auth()
-  if (!session)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const result = await parseAuthRequest(request, createSeriesSchema)
+  if (!result.ok) return result.response
 
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = createSeriesSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const { id, translations } = parsed.data
+  const { id, translations } = result.data
+  logger.debug({ id }, 'POST /api/series')
 
   try {
     const existing = await db
@@ -82,6 +70,7 @@ export async function POST(request: Request) {
       await upsertSeriesTranslation(id, 'es', translations.es)
     }
 
+    logger.info({ id }, 'POST /api/series: created')
     return NextResponse.json({ id }, { status: 201 })
   } catch (err) {
     logger.error(err, 'Failed to create series')

--- a/apps/web/app/api/upload/route.spec.ts
+++ b/apps/web/app/api/upload/route.spec.ts
@@ -9,7 +9,14 @@ jest.mock('@web/lib/auth/config', () => ({ auth: mockAuth }))
 jest.mock('@web/lib/cloudinary/upload', () => ({
   uploadImage: mockUploadImage,
 }))
-jest.mock('@web/lib/logger', () => ({ logger: { error: mockLoggerError } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
 
 const { POST } = require('./route') as {
   POST: (req: Request) => Promise<Response>

--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { auth } from '@web/lib/auth/config'
+import { requireAuth } from '@web/lib/api/parseRequest'
 import { uploadImage } from '@web/lib/cloudinary/upload'
 import { logger } from '@web/lib/logger'
 
@@ -13,10 +13,8 @@ const ALLOWED_TYPES = new Set([
 ])
 
 export async function POST(request: Request) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult.response
 
   let formData: FormData
   try {
@@ -50,6 +48,10 @@ export async function POST(request: Request) {
       file.type,
       altText,
       name || undefined,
+    )
+    logger.info(
+      { publicId: result.publicId, name },
+      'POST /api/upload: uploaded',
     )
     return NextResponse.json(result, { status: 201 })
   } catch (err) {

--- a/apps/web/app/api/users/[id]/route.spec.ts
+++ b/apps/web/app/api/users/[id]/route.spec.ts
@@ -18,7 +18,12 @@ jest.mock('@web/lib/auth/config', () => ({ auth: jest.fn() }))
 jest.mock('@web/lib/db/queries/users')
 jest.mock('bcryptjs')
 jest.mock('@web/lib/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn() },
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
 }))
 
 const mockAuth = auth as jest.Mock

--- a/apps/web/app/api/users/[id]/route.ts
+++ b/apps/web/app/api/users/[id]/route.ts
@@ -2,7 +2,7 @@ import bcrypt from 'bcryptjs'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAdminRequest, requireAdminAuth } from '@web/lib/api/parseRequest'
 import {
   countAdmins,
   deleteUser,
@@ -24,27 +24,12 @@ export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session || session.user.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const result = await parseAdminRequest(request, patchUserSchema)
+  if (!result.ok) return result.response
 
   const { id } = await params
-
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch (err) {
-    logger.error(err, 'PATCH /api/users/[id]: invalid JSON')
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = patchUserSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const { email, role, name, password } = parsed.data
+  const { email, role, name, password } = result.data
+  logger.debug({ id, email, role }, 'PATCH /api/users/[id]')
 
   if (email !== undefined) {
     const existing = await getUserByEmail(email)
@@ -91,6 +76,7 @@ export async function PATCH(
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
+  logger.info({ id }, 'PATCH /api/users/[id]: updated')
   return NextResponse.json(updated)
 }
 
@@ -98,12 +84,11 @@ export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await auth()
-  if (!session || session.user.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const authResult = await requireAdminAuth()
+  if (!authResult.ok) return authResult.response
 
   const { id } = await params
+  logger.debug({ id }, 'DELETE /api/users/[id]')
 
   const target = await getUserById(id)
   if (!target) {
@@ -130,5 +115,6 @@ export async function DELETE(
     )
   }
 
+  logger.info({ id }, 'DELETE /api/users/[id]: deleted')
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/app/api/users/route.spec.ts
+++ b/apps/web/app/api/users/route.spec.ts
@@ -16,7 +16,12 @@ jest.mock('@web/lib/auth/config', () => ({ auth: jest.fn() }))
 jest.mock('@web/lib/db/queries/users')
 jest.mock('bcryptjs')
 jest.mock('@web/lib/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn() },
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
 }))
 
 const mockAuth = auth as jest.Mock

--- a/apps/web/app/api/users/route.ts
+++ b/apps/web/app/api/users/route.ts
@@ -2,7 +2,7 @@ import bcrypt from 'bcryptjs'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { auth } from '@web/lib/auth/config'
+import { parseAdminRequest, requireAdminAuth } from '@web/lib/api/parseRequest'
 import {
   createUser,
   getUserByEmail,
@@ -12,12 +12,11 @@ import type { UserRole } from '@web/lib/db/schema'
 import { logger } from '@web/lib/logger'
 
 export async function GET() {
-  const session = await auth()
-  if (!session || session.user.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const authResult = await requireAdminAuth()
+  if (!authResult.ok) return authResult.response
 
   const users = await listUsers()
+  logger.debug({ count: users.length }, 'GET /api/users')
   return NextResponse.json({ data: users })
 }
 
@@ -29,25 +28,11 @@ const createUserSchema = z.object({
 })
 
 export async function POST(request: Request) {
-  const session = await auth()
-  if (!session || session.user.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const result = await parseAdminRequest(request, createUserSchema)
+  if (!result.ok) return result.response
 
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch (err) {
-    logger.error(err, 'POST /api/users: invalid JSON')
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  const parsed = createUserSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
-  }
-
-  const { email, password, role, name } = parsed.data
+  const { email, password, role, name } = result.data
+  logger.debug({ email, role }, 'POST /api/users')
 
   const existing = await getUserByEmail(email)
   if (existing) {
@@ -65,6 +50,7 @@ export async function POST(request: Request) {
       role: role as UserRole,
       name,
     })
+    logger.info({ id: user.id, email, role }, 'POST /api/users: created')
     return NextResponse.json(user, { status: 201 })
   } catch (err) {
     logger.error(err, 'POST /api/users: failed to create user')

--- a/apps/web/app/og/route.spec.tsx
+++ b/apps/web/app/og/route.spec.tsx
@@ -7,7 +7,14 @@ const mockLoggerWarn = jest.fn()
 jest.mock('./OgImageTemplate', () => ({
   OgImageTemplate: (props: unknown) => mockOgImageTemplate(props),
 }))
-jest.mock('@web/lib/logger', () => ({ logger: { warn: mockLoggerWarn } }))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    warn: mockLoggerWarn,
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
 
 jest.mock('next-cloudinary', () => ({
   getCldImageUrl: jest.fn(
@@ -26,22 +33,20 @@ jest.mock('next/og', () => ({
   }),
 }))
 
+jest.mock('axios')
+
 describe('GET /og', () => {
-  let mockFetch: jest.SpyInstance
+  let mockAxiosGet: jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockOgImageTemplate.mockReturnValue(null)
-    mockFetch = jest.spyOn(global, 'fetch').mockResolvedValue({
-      arrayBuffer: jest
-        .fn()
-        .mockResolvedValue(Buffer.from('fake-image-data').buffer),
-      headers: { get: jest.fn().mockReturnValue('image/jpeg') },
-    } as unknown as Response)
-  })
-
-  afterEach(() => {
-    mockFetch.mockRestore()
+    const axios = require('axios')
+    mockAxiosGet = axios.get as jest.Mock
+    mockAxiosGet.mockResolvedValue({
+      data: Buffer.from('fake-image-data').buffer,
+      headers: { 'content-type': 'image/jpeg' },
+    })
   })
 
   it('calls ImageResponse with 1200x630 dimensions', async () => {
@@ -76,20 +81,19 @@ describe('GET /og', () => {
     expect(getCldImageUrl).toHaveBeenCalledWith(
       expect.objectContaining({ src: 'blog/cover.jpg' }),
     )
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(mockAxiosGet).toHaveBeenCalledWith(
       'https://res.cloudinary.com/test/image/upload/cover.jpg',
+      expect.objectContaining({ responseType: 'arraybuffer' }),
     )
     const element = mockImageResponse.mock.calls[0][0]
     expect(element.props.cover).toMatch(/^data:image\/jpeg;base64,/)
   })
 
   it('uses image/jpeg fallback when content-type header is missing', async () => {
-    mockFetch.mockResolvedValue({
-      arrayBuffer: jest
-        .fn()
-        .mockResolvedValue(Buffer.from('fake-image-data').buffer),
-      headers: { get: jest.fn().mockReturnValue(null) },
-    } as unknown as Response)
+    mockAxiosGet.mockResolvedValue({
+      data: Buffer.from('fake-image-data').buffer,
+      headers: {},
+    })
     const { GET } = require('./route')
     await GET(
       new Request('http://localhost/og?title=Test&cover=blog%2Fcover.jpg'),
@@ -100,7 +104,7 @@ describe('GET /og', () => {
 
   it('passes null cover and logs warn when fetch fails', async () => {
     const err = new Error('Network error')
-    mockFetch.mockRejectedValue(err)
+    mockAxiosGet.mockRejectedValue(err)
     const { GET } = require('./route')
     await GET(
       new Request('http://localhost/og?title=Test&cover=blog%2Fcover.jpg'),
@@ -142,3 +146,5 @@ describe('GET /og', () => {
     expect(response).toBeDefined()
   })
 })
+
+export {}

--- a/apps/web/app/og/route.ts
+++ b/apps/web/app/og/route.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { getCldImageUrl } from 'next-cloudinary'
 import { ImageResponse } from 'next/og'
 import { type NextRequest } from 'next/server'
@@ -15,10 +16,12 @@ async function fetchCoverAsDataUri(publicId: string): Promise<string | null> {
       height: 630,
       crop: 'fill',
     })
-    const res = await fetch(url)
-    const buffer = await res.arrayBuffer()
-    const base64 = Buffer.from(buffer).toString('base64')
-    const contentType = res.headers.get('content-type') ?? 'image/jpeg'
+    const res = await axios.get<ArrayBuffer>(url, {
+      responseType: 'arraybuffer',
+    })
+    const base64 = Buffer.from(res.data).toString('base64')
+    const contentType =
+      (res.headers['content-type'] as string | undefined) ?? 'image/jpeg'
     return `data:${contentType};base64,${base64}`
   } catch (err) {
     logger.warn(err, 'Failed to fetch OG cover image')

--- a/apps/web/lib/api/parseRequest.ts
+++ b/apps/web/lib/api/parseRequest.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import { type ZodSchema } from 'zod'
+
+import { auth } from '@web/lib/auth/config'
+
+type Session = NonNullable<Awaited<ReturnType<typeof auth>>>
+
+type AuthOk = { ok: true; session: Session }
+type Err = { ok: false; response: NextResponse }
+type ParseOk<T> = { ok: true; data: T; session: Session }
+
+export async function requireAuth(): Promise<AuthOk | Err> {
+  const session = await auth()
+  if (!session)
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  return { ok: true, session }
+}
+
+export async function requireAdminAuth(): Promise<AuthOk | Err> {
+  const session = await auth()
+  if (!session || session.user.role !== 'admin')
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    }
+  return { ok: true, session }
+}
+
+export async function parseAuthRequest<T>(
+  request: Request,
+  schema: ZodSchema<T>,
+): Promise<ParseOk<T> | Err> {
+  const authResult = await requireAuth()
+  if (!authResult.ok) return authResult
+  return parseBody(request, schema, authResult.session)
+}
+
+export async function parseAdminRequest<T>(
+  request: Request,
+  schema: ZodSchema<T>,
+): Promise<ParseOk<T> | Err> {
+  const authResult = await requireAdminAuth()
+  if (!authResult.ok) return authResult
+  return parseBody(request, schema, authResult.session)
+}
+
+async function parseBody<T>(
+  request: Request,
+  schema: ZodSchema<T>,
+  session: Session,
+): Promise<ParseOk<T> | Err> {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }),
+    }
+  }
+
+  const parsed = schema.safeParse(body)
+  if (!parsed.success)
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: parsed.error.issues },
+        { status: 400 },
+      ),
+    }
+
+  return { ok: true, data: parsed.data, session }
+}

--- a/apps/web/lib/db/queries/posts.spec.ts
+++ b/apps/web/lib/db/queries/posts.spec.ts
@@ -186,22 +186,28 @@ describe('getPostByNumber', () => {
 })
 
 describe('getRelatedPosts', () => {
-  it('returns related posts in same category', async () => {
-    const relatedPost = {
+  it('returns category posts then tag posts', async () => {
+    const categoryPost = {
       ...mockPublicPost,
-      id: '01JWOTHER000000000000000000',
-      slug: 'other-post',
-      content: '# Related',
+      id: '01JWOTHER000000000000000001',
+      slug: 'category-post',
+      content: '# Category',
     }
-    // First call: getPostById for current post
+    const tagPost = {
+      ...mockPublicPost,
+      id: '01JWOTHER000000000000000002',
+      slug: 'tag-post',
+      content: '# Tag',
+    }
+    // Call 1: getPostById, Call 2: byCategory, Call 3: byTags
     mockDb.select
       .mockReturnValueOnce(
         makeChain([{ ...mockPublicPost, content: '# Hello' }]),
       )
-      // Second call: related query
-      .mockReturnValueOnce(makeChain([relatedPost]))
+      .mockReturnValueOnce(makeChain([categoryPost]))
+      .mockReturnValueOnce(makeChain([tagPost]))
     const result = await getRelatedPosts('01JWTEST000000000000000000', 'en')
-    expect(result).toEqual([relatedPost])
+    expect(result).toEqual([categoryPost, tagPost])
   })
 
   it('returns empty array when current post not found', async () => {
@@ -210,23 +216,38 @@ describe('getRelatedPosts', () => {
     expect(result).toEqual([])
   })
 
-  it('returns at most 3 randomly shuffled posts when more are available', async () => {
-    const allRelated = [1, 2, 3, 4, 5].map((n) => ({
+  it('skips tag query when category fills the limit', async () => {
+    const categoryPosts = [1, 2, 3].map((n) => ({
       ...mockPublicPost,
       id: `01JWOTHER${String(n).padStart(17, '0')}`,
-      slug: `related-${n}`,
-      content: `# Related ${n}`,
+      slug: `cat-${n}`,
+      content: `# Cat ${n}`,
     }))
+    // Call 1: getPostById, Call 2: byCategory returns 3 (fills limit=3, ceil(3*2/3)=2 but mock ignores LIMIT)
     mockDb.select
       .mockReturnValueOnce(
         makeChain([{ ...mockPublicPost, content: '# Hello' }]),
       )
-      .mockReturnValueOnce(makeChain(allRelated))
-    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0)
+      .mockReturnValueOnce(makeChain(categoryPosts))
     const result = await getRelatedPosts('01JWTEST000000000000000000', 'en')
-    randomSpy.mockRestore()
+    // tagTarget = 3 - 3 = 0, so no third query
     expect(result).toHaveLength(3)
-    result.forEach((post) => expect(allRelated).toContainEqual(post))
+    result.forEach((post) => expect(categoryPosts).toContainEqual(post))
+  })
+
+  it('returns only category posts when post has no tags', async () => {
+    const noTagsPost = { ...mockPublicPost, tags: [] }
+    const relatedPost = {
+      ...mockPublicPost,
+      id: '01JWOTHER000000000000000001',
+      slug: 'related',
+      content: '# Related',
+    }
+    mockDb.select
+      .mockReturnValueOnce(makeChain([{ ...noTagsPost, content: '# Hello' }]))
+      .mockReturnValueOnce(makeChain([relatedPost]))
+    const result = await getRelatedPosts('01JWTEST000000000000000000', 'en')
+    expect(result).toEqual([relatedPost])
   })
 })
 

--- a/apps/web/lib/db/queries/posts.ts
+++ b/apps/web/lib/db/queries/posts.ts
@@ -8,6 +8,7 @@ import {
   isNotNull,
   isNull,
   ne,
+  notInArray,
   or,
   sql,
 } from 'drizzle-orm'
@@ -203,15 +204,6 @@ export async function getPostBySlug(
   return rows[0] ?? null
 }
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const result = [...arr]
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[result[i], result[j]] = [result[j], result[i]]
-  }
-  return result
-}
-
 export async function getRelatedPosts(
   postId: string,
   locale: Locale,
@@ -220,23 +212,22 @@ export async function getRelatedPosts(
   const current = await getPostById(postId, locale)
   if (!current) return []
 
-  const allRelated = await db
+  const categoryTarget = Math.ceil((limit * 2) / 3)
+
+  const translationJoin = and(
+    eq(postTranslations.postId, posts.id),
+    eq(postTranslations.locale, locale),
+  )
+  const seriesJoin = and(
+    eq(seriesTranslations.seriesId, posts.seriesId),
+    eq(seriesTranslations.locale, locale),
+  )
+
+  const byCategory = await db
     .select(publicFieldsWithContent)
     .from(posts)
-    .innerJoin(
-      postTranslations,
-      and(
-        eq(postTranslations.postId, posts.id),
-        eq(postTranslations.locale, locale),
-      ),
-    )
-    .leftJoin(
-      seriesTranslations,
-      and(
-        eq(seriesTranslations.seriesId, posts.seriesId),
-        eq(seriesTranslations.locale, locale),
-      ),
-    )
+    .innerJoin(postTranslations, translationJoin)
+    .leftJoin(seriesTranslations, seriesJoin)
     .leftJoin(users, eq(users.id, posts.authorId))
     .where(
       and(
@@ -246,9 +237,36 @@ export async function getRelatedPosts(
         isNull(posts.deletedAt),
       ),
     )
-    .orderBy(desc(posts.publishedAt))
+    .orderBy(sql`random()`)
+    .limit(categoryTarget)
 
-  return shuffleArray(allRelated).slice(0, limit)
+  const tagTarget = limit - byCategory.length
+  let byTags: typeof byCategory = []
+
+  if (tagTarget > 0 && current.tags.length > 0) {
+    const excludeIds = [postId, ...byCategory.map((p) => p.id)]
+    byTags = await db
+      .select(publicFieldsWithContent)
+      .from(posts)
+      .innerJoin(postTranslations, translationJoin)
+      .leftJoin(seriesTranslations, seriesJoin)
+      .leftJoin(users, eq(users.id, posts.authorId))
+      .where(
+        and(
+          sql`${posts.tags} && ARRAY[${sql.join(
+            current.tags.map((t) => sql`${t}`),
+            sql`, `,
+          )}]`,
+          notInArray(posts.id, excludeIds),
+          eq(posts.status, 'published'),
+          isNull(posts.deletedAt),
+        ),
+      )
+      .orderBy(sql`random()`)
+      .limit(tagTarget)
+  }
+
+  return [...byCategory, ...byTags]
 }
 
 export type SeriesSummary = {
@@ -645,11 +663,10 @@ export async function getPostPublishedDates(
     conditions = sql`${conditions} AND p.id != ${excludeId}`
   }
   if (filters?.categories?.length) {
-    let catFilter = sql`p.category = ${filters.categories[0]}`
-    for (let i = 1; i < filters.categories.length; i++) {
-      catFilter = sql`${catFilter} OR p.category = ${filters.categories[i]}`
-    }
-    conditions = sql`${conditions} AND (${catFilter})`
+    conditions = sql`${conditions} AND p.category = ANY(ARRAY[${sql.join(
+      filters.categories.map((c) => sql`${c}`),
+      sql`, `,
+    )}])`
   }
   for (const tag of filters?.tags ?? []) {
     conditions = sql`${conditions} AND p.tags @> ARRAY[${tag}]::text[]`

--- a/apps/web/lib/db/queries/tags.spec.ts
+++ b/apps/web/lib/db/queries/tags.spec.ts
@@ -4,11 +4,16 @@ import { getAllTags, getAllTagsAdmin, getPostCountPerTag } from './tags'
 jest.mock('../index', () => ({
   db: {
     select: jest.fn(),
+    selectDistinct: jest.fn(),
     execute: jest.fn(),
   },
 }))
 
-const mockDb = db as unknown as { select: jest.Mock; execute: jest.Mock }
+const mockDb = db as unknown as {
+  select: jest.Mock
+  selectDistinct: jest.Mock
+  execute: jest.Mock
+}
 
 function makeChain(resolved: unknown) {
   const chain: Record<string, unknown> = {}
@@ -28,32 +33,23 @@ beforeEach(() => {
 })
 
 describe('getAllTags', () => {
-  it('returns deduplicated sorted tags from published posts', async () => {
-    mockDb.select.mockReturnValue(
-      makeChain([
-        { tag: 'typescript' },
-        { tag: 'javascript' },
-        { tag: 'typescript' },
-      ]),
+  it('returns sorted tags from published posts', async () => {
+    mockDb.selectDistinct.mockReturnValue(
+      makeChain([{ tag: 'javascript' }, { tag: 'typescript' }]),
     )
     const result = await getAllTags()
     expect(result).toEqual(['javascript', 'typescript'])
   })
 
   it('returns empty array when no published posts', async () => {
-    mockDb.select.mockReturnValue(makeChain([]))
+    mockDb.selectDistinct.mockReturnValue(makeChain([]))
     const result = await getAllTags()
     expect(result).toEqual([])
   })
 
-  it('deduplicates tags across posts', async () => {
-    mockDb.select.mockReturnValue(
-      makeChain([
-        { tag: 'react' },
-        { tag: 'next' },
-        { tag: 'react' },
-        { tag: 'next' },
-      ]),
+  it('maps tag rows to strings', async () => {
+    mockDb.selectDistinct.mockReturnValue(
+      makeChain([{ tag: 'next' }, { tag: 'react' }]),
     )
     const result = await getAllTags()
     expect(result).toEqual(['next', 'react'])
@@ -62,20 +58,16 @@ describe('getAllTags', () => {
 })
 
 describe('getAllTagsAdmin', () => {
-  it('returns deduplicated sorted tags from all non-deleted posts', async () => {
-    mockDb.select.mockReturnValue(
-      makeChain([
-        { tag: 'typescript' },
-        { tag: 'javascript' },
-        { tag: 'typescript' },
-      ]),
+  it('returns sorted tags from all non-deleted posts', async () => {
+    mockDb.selectDistinct.mockReturnValue(
+      makeChain([{ tag: 'javascript' }, { tag: 'typescript' }]),
     )
     const result = await getAllTagsAdmin()
     expect(result).toEqual(['javascript', 'typescript'])
   })
 
   it('returns empty array when no posts', async () => {
-    mockDb.select.mockReturnValue(makeChain([]))
+    mockDb.selectDistinct.mockReturnValue(makeChain([]))
     const result = await getAllTagsAdmin()
     expect(result).toEqual([])
   })

--- a/apps/web/lib/db/queries/tags.ts
+++ b/apps/web/lib/db/queries/tags.ts
@@ -5,20 +5,22 @@ import { posts } from '../schema'
 
 export async function getAllTags(): Promise<string[]> {
   const rows = await db
-    .select({ tag: sql<string>`unnest(${posts.tags})` })
+    .selectDistinct({ tag: sql<string>`unnest(${posts.tags})` })
     .from(posts)
     .where(and(eq(posts.status, 'published'), isNull(posts.deletedAt)))
+    .orderBy(sql`1`)
 
-  return [...new Set(rows.map((r) => r.tag))].sort()
+  return rows.map((r) => r.tag)
 }
 
 export async function getAllTagsAdmin(): Promise<string[]> {
   const rows = await db
-    .select({ tag: sql<string>`unnest(${posts.tags})` })
+    .selectDistinct({ tag: sql<string>`unnest(${posts.tags})` })
     .from(posts)
     .where(isNull(posts.deletedAt))
+    .orderBy(sql`1`)
 
-  return [...new Set(rows.map((r) => r.tag))].sort()
+  return rows.map((r) => r.tag)
 }
 
 export type TagWithCount = {
@@ -38,11 +40,10 @@ export async function getPostCountPerTag(
     conditions = sql`${conditions} AND p.id != ${excludeId}`
   }
   if (filters?.categories?.length) {
-    let catFilter = sql`p.category = ${filters.categories[0]}`
-    for (let i = 1; i < filters.categories.length; i++) {
-      catFilter = sql`${catFilter} OR p.category = ${filters.categories[i]}`
-    }
-    conditions = sql`${conditions} AND (${catFilter})`
+    conditions = sql`${conditions} AND p.category = ANY(ARRAY[${sql.join(
+      filters.categories.map((c) => sql`${c}`),
+      sql`, `,
+    )}])`
   }
   if (filters?.year != null) {
     conditions = sql`${conditions} AND date_part('year', p.published_at)::int = ${filters.year}`

--- a/apps/web/lib/db/queries/users.spec.ts
+++ b/apps/web/lib/db/queries/users.spec.ts
@@ -165,7 +165,7 @@ describe('deleteUser', () => {
 
 describe('countAdmins', () => {
   it('returns count of admin users', async () => {
-    mockDb.select.mockReturnValue(makeChain([{ id: 'a' }, { id: 'b' }]))
+    mockDb.select.mockReturnValue(makeChain([{ count: 2 }]))
     const result = await countAdmins()
     expect(result).toBe(2)
   })

--- a/apps/web/lib/db/queries/users.ts
+++ b/apps/web/lib/db/queries/users.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from 'drizzle-orm'
+import { asc, count, eq } from 'drizzle-orm'
 import { ulid } from 'ulid'
 
 import { db } from '../index'
@@ -116,9 +116,9 @@ export async function deleteUser(id: string): Promise<void> {
 }
 
 export async function countAdmins(): Promise<number> {
-  const rows = await db
-    .select({ id: users.id })
+  const [row] = await db
+    .select({ count: count() })
     .from(users)
     .where(eq(users.role, 'admin'))
-  return rows.length
+  return row?.count ?? 0
 }

--- a/apps/web/lib/logger.ts
+++ b/apps/web/lib/logger.ts
@@ -1,5 +1,14 @@
 import pino from 'pino'
 
+// Log levels (most → least verbose): trace → debug → info → warn → error → fatal
+// Default: info  (info + warn + error)
+// Enable debug:  LOG_LEVEL=debug  (adds request-level traces)
+// Enable trace:  LOG_LEVEL=trace  (adds db/framework internals)
+// Silence:       LOG_LEVEL=silent (used in tests)
+//
+// Runtime override: set LOG_LEVEL env var before starting the server.
+// Example: LOG_LEVEL=debug yarn start:web
+
 export function createLogger() {
   const level =
     process.env.LOG_LEVEL ??

--- a/libs/combobox/src/lib/combobox.spec.tsx
+++ b/libs/combobox/src/lib/combobox.spec.tsx
@@ -99,6 +99,14 @@ describe('Combobox', () => {
     )
   })
 
+  it('passes a stable instanceId to prevent hydration mismatch', () => {
+    renderCombobox()
+    const [props] = mockCreatableSelect.mock.calls[0] as [
+      Record<string, unknown>,
+    ]
+    expect(props.instanceId).toBeDefined()
+  })
+
   function getIsValidNewOption() {
     const props = mockCreatableSelect.mock.calls[0][0] as {
       isValidNewOption: (

--- a/libs/combobox/src/lib/combobox.tsx
+++ b/libs/combobox/src/lib/combobox.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useId } from 'react'
 import CreatableSelect from 'react-select/creatable'
 
 import { StyledComboboxWrapper } from './combobox.styles'
@@ -23,6 +24,7 @@ export function Combobox({
   isValidNewOption,
   'data-testid': testId,
 }: ComboboxProps) {
+  const uid = useId()
   const selectOptions: ComboboxOption[] = options.map((opt) => ({
     value: opt,
     label: opt,
@@ -39,6 +41,7 @@ export function Combobox({
         isMulti
         unstyled
         classNamePrefix="combobox"
+        instanceId={uid}
         options={selectOptions}
         value={selectValue}
         onChange={(selected) => onChange(selected.map((opt) => opt.value))}

--- a/libs/select/src/lib/select.spec.tsx
+++ b/libs/select/src/lib/select.spec.tsx
@@ -147,11 +147,21 @@ describe('Select', () => {
     )
   })
 
-  it('forwards id as inputId', () => {
+  it('forwards id as inputId and instanceId', () => {
     renderSelect({ id: 'my-select' })
     expect(mockReactSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ inputId: 'my-select' }),
+      expect.objectContaining({
+        inputId: 'my-select',
+        instanceId: 'my-select',
+      }),
     )
+  })
+
+  it('uses generated instanceId when id is not provided', () => {
+    renderSelect()
+    const [props] = mockReactSelect.mock.calls[0] as [Record<string, unknown>]
+    expect(props.instanceId).toBeDefined()
+    expect(props.inputId).toBeUndefined()
   })
 
   it('uses ReactSelect by default when isCreatable is false', () => {

--- a/libs/select/src/lib/select.tsx
+++ b/libs/select/src/lib/select.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useId } from 'react'
 import ReactSelect from 'react-select'
 import CreatableReactSelect from 'react-select/creatable'
 
@@ -40,6 +41,7 @@ export function Select({
   isClearable = false,
   'data-testid': testId,
 }: SelectProps) {
+  const uid = useId()
   const rsOptions: RsOption[] = options.map((o) => ({
     value: o.value,
     label: o.label,
@@ -52,6 +54,7 @@ export function Select({
 
   const commonProps = {
     inputId: id,
+    instanceId: id ?? uid,
     unstyled: true,
     classNamePrefix: 'select',
     options: rsOptions,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,6 +11,16 @@
       "sourceType": "autoskills-registry",
       "computedHash": "c124390cc3441844903ada94cb5820b23d922f2d0ad34e01e029e410197c8a32"
     },
+    "deploy-to-vercel": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "698dfb0ec0cf3e8d97c3f181e13b37b3b8fbc872a4b031d812adb4193f66035e"
+    },
+    "drizzle": {
+      "source": "bobmatnyc/claude-mpm-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "ee38c0b7737febd7409d84e613099a0f276e215e0bbda418b2593786ea8a4754"
+    },
     "frontend-design": {
       "source": "anthropics/skills",
       "sourceType": "autoskills-registry",
@@ -25,6 +35,11 @@
       "source": "affaan-m/everything-claude-code",
       "sourceType": "autoskills-registry",
       "computedHash": "4c1e0c6805760534d8fd1a9fa2e4b5eb700b402f054254383437bd679d341cbd"
+    },
+    "neon-postgres": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "afa90370212ed99bb472c8d64ca6a5169e3608a6c0d3e570565e7997b1dc81b2"
     },
     "next-best-practices": {
       "source": "vercel-labs/next-skills",
@@ -56,6 +71,11 @@
       "sourceType": "autoskills-registry",
       "computedHash": "502eb06700e2c3cb1bd7f710860528f72281320bd5171a2087b05a090b573dc1"
     },
+    "react-hook-form": {
+      "source": "pproenca/dot-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "5cac0a77035b36714c95df1f0ccc9955713fbfc87734f189a16f5aac903eccda"
+    },
     "seo": {
       "source": "addyosmani/web-quality-skills",
       "sourceType": "autoskills-registry",
@@ -65,6 +85,11 @@
       "source": "wshobson/agents",
       "sourceType": "autoskills-registry",
       "computedHash": "5ca0e177c6aaaba1889255691224daafdb7d71f317cc70bede1590d3907ded42"
+    },
+    "zod": {
+      "source": "pproenca/dot-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "aa8a97195b07763d37494b511f48be90979fd6826c031956c831cfc58f6a24b8"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Extract shared admin styled components (`AdminForm`, `AdminPage`, `AdminTable`, `ConfirmDeleteModal`) to reduce duplication across admin pages
- Extract `parseRequest` utility and consolidate API route error handling
- Fix SQL `ARRAY[]` parameter serialization — Drizzle was emitting row constructors `($1,$2,$3)` instead of `ARRAY[$1,$2,$3]` for `&&` operator and `ANY()` filters in `posts.ts` and `tags.ts`
- Fix `react-select` hydration mismatch by passing `useId()` as `instanceId` in `@sdlgr/select` and `@sdlgr/combobox`
- Fix test failures: logger mock missing levels, `og/route` axios mock, `countAdmins` branch coverage, `getRelatedPosts` 3-query architecture
- Add E2E test: editor role is redirected from `/admin/users` to `/admin/posts`

## Test plan

- [x] `yarn test:all` passes with 100% coverage
- [x] No hydration warnings on `/admin/posts/[id]`
- [x] E2E: editor account cannot access `/admin/users`