### PR TITLE
feat: limit waypoint select dropdown to 5 visible items

### DIFF
--- a/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.tsx
@@ -253,6 +253,7 @@ export function GpxMapModal({ isOpen, onInsert, onCancel }: GpxMapModalProps) {
                       label: name,
                     }))}
                     isSearchable
+                    maxMenuHeight={160}
                     data-testid="waypoint-select"
                   />
                   <StyledPickImageButton

--- a/libs/select/src/lib/select.spec.tsx
+++ b/libs/select/src/lib/select.spec.tsx
@@ -189,4 +189,17 @@ describe('Select', () => {
       expect.objectContaining({ isSearchable: true }),
     )
   })
+
+  it('passes maxMenuHeight when provided', () => {
+    renderSelect({ maxMenuHeight: 160 })
+    expect(mockReactSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ maxMenuHeight: 160 }),
+    )
+  })
+
+  it('omits maxMenuHeight when not provided', () => {
+    renderSelect()
+    const [props] = mockReactSelect.mock.calls[0] as [Record<string, unknown>]
+    expect(props).not.toHaveProperty('maxMenuHeight')
+  })
 })

--- a/libs/select/src/lib/select.tsx
+++ b/libs/select/src/lib/select.tsx
@@ -21,6 +21,7 @@ export interface SelectProps {
   isSearchable?: boolean
   isCreatable?: boolean
   isClearable?: boolean
+  maxMenuHeight?: number
   'data-testid'?: string
 }
 
@@ -39,6 +40,7 @@ export function Select({
   isSearchable = false,
   isCreatable = false,
   isClearable = false,
+  maxMenuHeight,
   'data-testid': testId,
 }: SelectProps) {
   const uid = useId()
@@ -63,6 +65,7 @@ export function Select({
     placeholder,
     isSearchable,
     isClearable,
+    ...(maxMenuHeight !== undefined && { maxMenuHeight }),
   }
 
   return (


### PR DESCRIPTION
Adds maxMenuHeight prop to Select component and passes 160px (≈5 options) to the waypoints select in GpxMapModal.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Mandatory gif:

![](https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif)
