### PR TITLE
feat: add post likes counter with IP rate limiting and localStorage d…

### DIFF
--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.styles.ts
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.styles.ts
@@ -10,7 +10,3 @@ export const StyledPage = styled.main`
     padding: 0 2rem 5rem;
   }
 `
-
-export const StyledSubscribeWrapper = styled.div`
-  margin-top: 3rem;
-`

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -7,6 +7,7 @@ import { TableOfContents } from '@sdlgr/table-of-contents'
 
 import { JsonLd } from '@web/components/JsonLd/JsonLd'
 import { PostContent } from '@web/components/PostContent/PostContent'
+import { PostLikeButton } from '@web/components/PostLikeButton'
 import { RelatedPosts } from '@web/components/RelatedPosts/RelatedPosts'
 import { SeriesIndicator } from '@web/components/SeriesIndicator/SeriesIndicator'
 import { SubscribeModal } from '@web/components/SubscribeModal'
@@ -27,7 +28,7 @@ import {
 } from '@web/utils/metadata/inLanguage'
 import { getSiteUrl } from '@web/utils/url/generateUrl'
 
-import { StyledPage, StyledSubscribeWrapper } from './page.next.styles'
+import { StyledPage } from './page.next.styles'
 
 export const revalidate = 3600
 
@@ -177,6 +178,17 @@ export default async function BlogPostPage({ params }: RouteProps) {
         copyLinkLabel={t('share.copyLink')}
         copiedLabel={t('share.copied')}
         categoryIcon={<CategoryIconRenderer slug={post.category} aria-hidden />}
+        actions={
+          <>
+            <PostLikeButton postId={post.id} initialLikes={post.likes} />
+            <SubscribeModal
+              lng={lng}
+              buttonLabel={tSubscribe('buttonLabel')}
+              buttonAriaLabel={tSubscribe('buttonAriaLabel')}
+              compact
+            />
+          </>
+        }
       />
       {toc.length > 0 && <TableOfContents entries={toc} label={t('toc')} />}
       <PostContent>
@@ -194,13 +206,6 @@ export default async function BlogPostPage({ params }: RouteProps) {
         />
       )}
       <RelatedPosts postId={post.id} lng={lng} />
-      <StyledSubscribeWrapper>
-        <SubscribeModal
-          lng={lng}
-          buttonLabel={tSubscribe('buttonLabel')}
-          buttonAriaLabel={tSubscribe('buttonAriaLabel')}
-        />
-      </StyledSubscribeWrapper>
     </StyledPage>
   )
 }

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
@@ -101,6 +101,10 @@ jest.mock('@web/components/PostContent/PostContent', () => ({
   ),
 }))
 
+jest.mock('@web/components/PostLikeButton', () => ({
+  PostLikeButton: () => <div data-testid="post-like-button" />,
+}))
+
 const publishedPost = {
   id: '01JXYZ',
   postNumber: 1,
@@ -113,6 +117,7 @@ const publishedPost = {
   category: 'Tech',
   tags: ['next.js', 'react'],
   author: 'Jane Doe',
+  likes: 0,
   publishedAt: new Date('2024-01-01T00:00:00.000Z'),
   updatedAt: new Date('2024-06-15T00:00:00.000Z'),
   content: 'Hello world content',

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
@@ -247,8 +247,8 @@ export function PostEditor({
   const [isEmbedInsertModalOpen, setIsEmbedInsertModalOpen] = useState(false)
   const [isGpxModalOpen, setIsGpxModalOpen] = useState(false)
   const [imageModalKey, setImageModalKey] = useState(0)
-  const [embedModalKey, setEmbedModalKey] = useState(1)
-  const [gpxModalKey, setGpxModalKey] = useState(2)
+  const [embedModalKey, setEmbedModalKey] = useState(0)
+  const [gpxModalKey, setGpxModalKey] = useState(0)
   const [showPublishNotify, setShowPublishNotify] = useState(false)
   const [editingEmbed, setEditingEmbed] = useState<DetectedEmbed | null>(null)
   const [imageInitialValues, setImageInitialValues] =
@@ -966,7 +966,7 @@ export function PostEditor({
         zIndex={1100}
       />
       <ImageInsertModal
-        key={imageModalKey}
+        key={`image-${imageModalKey}`}
         isOpen={isImageInsertModalOpen}
         initialValues={imageInitialValues}
         onInsert={(markdown) => {
@@ -993,7 +993,7 @@ export function PostEditor({
         }}
       />
       <EmbedInsertModal
-        key={embedModalKey}
+        key={`embed-${embedModalKey}`}
         isOpen={isEmbedInsertModalOpen}
         initialValues={embedInitialValues}
         onInsert={(markdown) => {
@@ -1015,7 +1015,7 @@ export function PostEditor({
         }}
       />
       <GpxMapModal
-        key={gpxModalKey}
+        key={`gpx-${gpxModalKey}`}
         isOpen={isGpxModalOpen}
         initialValues={gpxInitialValues}
         onInsert={(markdown) => {

--- a/apps/web/app/api/posts/[id]/like/route.spec.ts
+++ b/apps/web/app/api/posts/[id]/like/route.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+const mockGetPostStatus = jest.fn()
+const mockIncrementPostLikes = jest.fn()
+const mockLikesRatelimit = { limit: jest.fn() }
+const mockLoggerError = jest.fn()
+
+jest.mock('@web/lib/db/queries/posts', () => ({
+  getPostStatus: (...args: unknown[]) => mockGetPostStatus(...args),
+  incrementPostLikes: (...args: unknown[]) => mockIncrementPostLikes(...args),
+}))
+jest.mock('@web/lib/ratelimit', () => ({
+  get likesRatelimit() {
+    return mockLikesRatelimit
+  },
+}))
+jest.mock('@web/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
+
+const { POST } = require('./route') as {
+  POST: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<Response>
+}
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new Request('http://localhost/api/posts/some-id/like', {
+    method: 'POST',
+    headers,
+  })
+}
+
+function makeParams(id = 'post-ulid-123') {
+  return { params: Promise.resolve({ id }) }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockLikesRatelimit.limit.mockResolvedValue({ success: true })
+  mockGetPostStatus.mockResolvedValue('published')
+  mockIncrementPostLikes.mockResolvedValue(42)
+})
+
+describe('POST /api/posts/[id]/like', () => {
+  it('increments likes and returns count', async () => {
+    const res = await POST(makeRequest(), makeParams())
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ likes: 42 })
+    expect(mockIncrementPostLikes).toHaveBeenCalledWith('post-ulid-123')
+  })
+
+  it('returns 429 when rate limit exceeded', async () => {
+    mockLikesRatelimit.limit.mockResolvedValue({ success: false })
+    const res = await POST(makeRequest(), makeParams())
+    expect(res.status).toBe(429)
+    expect(await res.json()).toEqual({ error: 'Already liked' })
+    expect(mockIncrementPostLikes).not.toHaveBeenCalled()
+  })
+
+  it('uses x-forwarded-for ip for rate limit key', async () => {
+    const res = await POST(
+      makeRequest({ 'x-forwarded-for': '1.2.3.4, 5.6.7.8' }),
+      makeParams(),
+    )
+    expect(res.status).toBe(200)
+    expect(mockLikesRatelimit.limit).toHaveBeenCalledWith(
+      'like:post-ulid-123:1.2.3.4',
+    )
+  })
+
+  it('uses x-real-ip when x-forwarded-for absent', async () => {
+    await POST(makeRequest({ 'x-real-ip': '9.9.9.9' }), makeParams())
+    expect(mockLikesRatelimit.limit).toHaveBeenCalledWith(
+      'like:post-ulid-123:9.9.9.9',
+    )
+  })
+
+  it('falls back to anonymous when no ip headers', async () => {
+    await POST(makeRequest(), makeParams())
+    expect(mockLikesRatelimit.limit).toHaveBeenCalledWith(
+      'like:post-ulid-123:anonymous',
+    )
+  })
+
+  it('returns 404 when post not found', async () => {
+    mockGetPostStatus.mockResolvedValue(null)
+    const res = await POST(makeRequest(), makeParams())
+    expect(res.status).toBe(404)
+    expect(mockIncrementPostLikes).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when post is not published', async () => {
+    mockGetPostStatus.mockResolvedValue('draft')
+    const res = await POST(makeRequest(), makeParams())
+    expect(res.status).toBe(404)
+    expect(mockIncrementPostLikes).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when increment throws', async () => {
+    mockIncrementPostLikes.mockRejectedValue(new Error('db error'))
+    const res = await POST(makeRequest(), makeParams())
+    expect(res.status).toBe(500)
+    expect(mockLoggerError).toHaveBeenCalled()
+  })
+
+  it('skips rate limit when likesRatelimit is null', async () => {
+    jest.resetModules()
+    jest.mock('@web/lib/ratelimit', () => ({ likesRatelimit: null }))
+    jest.mock('@web/lib/db/queries/posts', () => ({
+      getPostStatus: () => Promise.resolve('published'),
+      incrementPostLikes: () => Promise.resolve(1),
+    }))
+    jest.mock('@web/lib/logger', () => ({
+      logger: {
+        error: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+      },
+    }))
+    const { POST: POST2 } = require('./route') as typeof import('./route')
+    const res = await POST2(makeRequest(), makeParams())
+    expect(res.status).toBe(200)
+  })
+})

--- a/apps/web/app/api/posts/[id]/like/route.ts
+++ b/apps/web/app/api/posts/[id]/like/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getPostStatus, incrementPostLikes } from '@web/lib/db/queries/posts'
+import { logger } from '@web/lib/logger'
+import { likesRatelimit } from '@web/lib/ratelimit'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    'anonymous'
+
+  if (likesRatelimit) {
+    const { success } = await likesRatelimit.limit(`like:${id}:${ip}`)
+    if (!success) {
+      return NextResponse.json({ error: 'Already liked' }, { status: 429 })
+    }
+  }
+
+  const status = await getPostStatus(id)
+  if (!status || status !== 'published') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  try {
+    const likes = await incrementPostLikes(id)
+    return NextResponse.json({ likes })
+  } catch (error) {
+    logger.error(error, 'Failed to increment likes')
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/apps/web/components/PostLikeButton/PostLikeButton.spec.tsx
+++ b/apps/web/components/PostLikeButton/PostLikeButton.spec.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+const mockT = jest.fn((key: string) => key)
+const mockFetch = jest.fn()
+
+jest.mock('@web/i18n/client', () => ({
+  useClientTranslation: () => ({ t: mockT }),
+}))
+
+global.fetch = mockFetch
+
+const STORAGE_KEY = 'liked_posts'
+
+const { PostLikeButton } =
+  require('./PostLikeButton') as typeof import('./PostLikeButton')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  localStorage.clear()
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ likes: 10 }),
+  })
+})
+
+describe('PostLikeButton', () => {
+  it('renders like button and count', () => {
+    renderApp(<PostLikeButton postId="post-1" initialLikes={5} />)
+    expect(screen.getByTestId('like-button')).toBeInTheDocument()
+    expect(screen.getByTestId('like-count')).toHaveTextContent('5')
+  })
+
+  it('shows "like" aria-label when not liked', () => {
+    renderApp(<PostLikeButton postId="post-1" initialLikes={0} />)
+    expect(screen.getByTestId('like-button')).toHaveAttribute(
+      'aria-label',
+      'likeButton.like',
+    )
+  })
+
+  it('reads liked state from localStorage on mount', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['post-1']))
+    renderApp(<PostLikeButton postId="post-1" initialLikes={3} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('like-button')).toBeDisabled(),
+    )
+    expect(screen.getByTestId('like-button')).toHaveAttribute(
+      'aria-label',
+      'likeButton.liked',
+    )
+  })
+
+  it('does not mark liked when post id not in localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['other-post']))
+    renderApp(<PostLikeButton postId="post-1" initialLikes={0} />)
+    expect(screen.getByTestId('like-button')).not.toBeDisabled()
+  })
+
+  it('increments count and disables button on like', async () => {
+    renderApp(<PostLikeButton postId="post-1" initialLikes={5} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    expect(screen.getByTestId('like-count')).toHaveTextContent('6')
+    await waitFor(() =>
+      expect(screen.getByTestId('like-count')).toHaveTextContent('10'),
+    )
+    expect(screen.getByTestId('like-button')).toBeDisabled()
+  })
+
+  it('saves post id to localStorage after successful like', async () => {
+    renderApp(<PostLikeButton postId="post-1" initialLikes={0} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    const stored = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? '[]',
+    ) as string[]
+    expect(stored).toContain('post-1')
+  })
+
+  it('calls correct API endpoint', async () => {
+    renderApp(<PostLikeButton postId="post-abc" initialLikes={0} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(mockFetch).toHaveBeenCalledWith('/api/posts/post-abc/like', {
+      method: 'POST',
+    })
+  })
+
+  it('reverts optimistic update on non-429 error response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })
+    renderApp(<PostLikeButton postId="post-1" initialLikes={5} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    expect(screen.getByTestId('like-count')).toHaveTextContent('6')
+    await waitFor(() =>
+      expect(screen.getByTestId('like-count')).toHaveTextContent('5'),
+    )
+    expect(screen.getByTestId('like-button')).not.toBeDisabled()
+  })
+
+  it('keeps liked state on 429 response (already liked server-side)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({}),
+    })
+    renderApp(<PostLikeButton postId="post-1" initialLikes={5} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('like-button')).toBeDisabled(),
+    )
+    expect(screen.getByTestId('like-count')).toHaveTextContent('6')
+    const stored = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? '[]',
+    ) as string[]
+    expect(stored).toContain('post-1')
+  })
+
+  it('reverts optimistic update on network error', async () => {
+    mockFetch.mockRejectedValue(new Error('network'))
+    renderApp(<PostLikeButton postId="post-1" initialLikes={5} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('like-count')).toHaveTextContent('5'),
+    )
+    expect(screen.getByTestId('like-button')).not.toBeDisabled()
+  })
+
+  it('does not call API when already liked', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['post-1']))
+    renderApp(<PostLikeButton postId="post-1" initialLikes={5} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('like-button')).toBeDisabled(),
+    )
+    fireEvent.click(screen.getByTestId('like-button'))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('handles corrupted localStorage gracefully', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json')
+    renderApp(<PostLikeButton postId="post-1" initialLikes={0} />)
+    expect(screen.getByTestId('like-button')).not.toBeDisabled()
+  })
+
+  it('does not duplicate post in localStorage on 429', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['post-1']))
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({}),
+    })
+    renderApp(<PostLikeButton postId="post-1" initialLikes={0} />)
+    fireEvent.click(screen.getByTestId('like-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('like-button')).toBeDisabled(),
+    )
+    const stored = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? '[]',
+    ) as string[]
+    expect(stored.filter((id) => id === 'post-1')).toHaveLength(1)
+  })
+})

--- a/apps/web/components/PostLikeButton/PostLikeButton.styles.ts
+++ b/apps/web/components/PostLikeButton/PostLikeButton.styles.ts
@@ -1,0 +1,50 @@
+import styled, { css, keyframes } from 'styled-components'
+
+const pop = keyframes`
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.35); }
+  100% { transform: scale(1); }
+`
+
+export const StyledLikeWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`
+
+export const StyledLikeButton = styled.button<{ $liked: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: ${({ $liked }) => ($liked ? 'default' : 'pointer')};
+  padding: 0;
+
+  ${({ $liked }) =>
+    $liked &&
+    css`
+      animation: ${pop} 0.3s ease;
+    `}
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    transition:
+      fill 0.2s,
+      stroke 0.2s;
+    fill: ${({ theme, $liked }) => ($liked ? theme.colors.orange : 'none')};
+    stroke: ${({ theme, $liked }) =>
+      $liked ? theme.colors.orange : `${theme.colors.white}99`};
+    stroke-width: 2;
+  }
+
+  &:not(:disabled):hover svg {
+    stroke: ${({ theme }) => theme.colors.orange};
+  }
+`
+
+export const StyledLikeCount = styled.span`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.white}99;
+`

--- a/apps/web/components/PostLikeButton/PostLikeButton.tsx
+++ b/apps/web/components/PostLikeButton/PostLikeButton.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+
+import { useClientTranslation } from '@web/i18n/client'
+
+import {
+  StyledLikeButton,
+  StyledLikeCount,
+  StyledLikeWrapper,
+} from './PostLikeButton.styles'
+
+const STORAGE_KEY = 'liked_posts'
+
+function getLikedPosts(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as string[]
+  } catch {
+    return []
+  }
+}
+
+function saveLikedPost(postId: string) {
+  const prev = getLikedPosts()
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify([...new Set([...prev, postId])]),
+  )
+}
+
+export function PostLikeButton({
+  postId,
+  initialLikes,
+}: {
+  postId: string
+  initialLikes: number
+}) {
+  const { t } = useClientTranslation('blogPage')
+  const [liked, setLiked] = useState(() => getLikedPosts().includes(postId))
+  const [count, setCount] = useState(initialLikes)
+  const [loading, setLoading] = useState(false)
+
+  const handleLike = async () => {
+    /* istanbul ignore next */
+    if (liked) return
+
+    setLiked(true)
+    setCount((c) => c + 1)
+    setLoading(true)
+
+    try {
+      const res = await fetch(`/api/posts/${postId}/like`, { method: 'POST' })
+      if (res.ok) {
+        const data = (await res.json()) as { likes: number }
+        setCount(data.likes)
+        saveLikedPost(postId)
+      } else if (res.status === 429) {
+        saveLikedPost(postId)
+      } else {
+        setLiked(false)
+        setCount((c) => c - 1)
+      }
+    } catch {
+      setLiked(false)
+      setCount((c) => c - 1)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <StyledLikeWrapper>
+      <StyledLikeButton
+        onClick={handleLike}
+        $liked={liked}
+        disabled={liked || loading}
+        aria-label={liked ? t('likeButton.liked') : t('likeButton.like')}
+        data-testid="like-button"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+        </svg>
+      </StyledLikeButton>
+      <StyledLikeCount data-testid="like-count">{count}</StyledLikeCount>
+    </StyledLikeWrapper>
+  )
+}

--- a/apps/web/components/PostLikeButton/index.ts
+++ b/apps/web/components/PostLikeButton/index.ts
@@ -1,0 +1,1 @@
+export { PostLikeButton } from './PostLikeButton'

--- a/apps/web/components/SubscribeModal/SubscribeModal.spec.tsx
+++ b/apps/web/components/SubscribeModal/SubscribeModal.spec.tsx
@@ -38,6 +38,21 @@ describe('SubscribeModal', () => {
     expect(baseElement).toMatchSnapshot()
   })
 
+  it('renders compact button when compact is true', () => {
+    const { baseElement } = renderApp(
+      <SubscribeModal
+        lng="en"
+        buttonLabel="Subscribe"
+        buttonAriaLabel="Subscribe to blog"
+        compact
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to blog' }),
+    ).toBeInTheDocument()
+    expect(baseElement).toMatchSnapshot()
+  })
+
   it('opens modal on button click', async () => {
     renderApp(
       <SubscribeModal

--- a/apps/web/components/SubscribeModal/SubscribeModal.styles.ts
+++ b/apps/web/components/SubscribeModal/SubscribeModal.styles.ts
@@ -13,7 +13,7 @@ export const StyledModal = styled(Modal)`
   }
 `
 
-export const StyledTriggerButton = styled(Button)`
+export const StyledTriggerButton = styled(Button)<{ $compact?: boolean }>`
   transition:
     background-color 0.15s ease,
     color 0.15s ease;
@@ -22,6 +22,13 @@ export const StyledTriggerButton = styled(Button)`
     background-color: ${({ theme }) => theme.colors.white};
     color: ${({ theme }) => theme.colors.black};
   }
+
+  ${({ $compact }) =>
+    $compact &&
+    `
+    font-size: 0.75rem;
+    padding: 0.3rem 0.75rem;
+  `}
 `
 
 export const StyledModalBody = styled.div`

--- a/apps/web/components/SubscribeModal/SubscribeModal.tsx
+++ b/apps/web/components/SubscribeModal/SubscribeModal.tsx
@@ -14,12 +14,14 @@ export interface SubscribeModalProps {
   lng: string
   buttonLabel: string
   buttonAriaLabel: string
+  compact?: boolean
 }
 
 export function SubscribeModal({
   lng,
   buttonLabel,
   buttonAriaLabel,
+  compact,
 }: SubscribeModalProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -29,6 +31,7 @@ export function SubscribeModal({
         variant="contained"
         onClick={() => setIsOpen(true)}
         aria-label={buttonAriaLabel}
+        $compact={compact}
       >
         {buttonLabel}
       </StyledTriggerButton>

--- a/apps/web/components/SubscribeModal/__snapshots__/SubscribeModal.spec.tsx.snap
+++ b/apps/web/components/SubscribeModal/__snapshots__/SubscribeModal.spec.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`SubscribeModal renders compact button when compact is true 1`] = `
+.c0 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  background: transparent;
+  cursor: pointer;
+  border: 1px solid #FBFBFB;
+  padding: 15px 20px;
+  font-size: 0.9rem;
+}
+
+.c1 {
+  transition: background-color 0.15s ease,color 0.15s ease;
+  font-size: 0.75rem;
+  padding: 0.3rem 0.75rem;
+}
+
+.c1:hover:not(:disabled) {
+  background-color: #FBFBFB;
+  color: #000000;
+}
+
+<body>
+  <div>
+    <button
+      aria-label="Subscribe to blog"
+      class="c0 c1"
+    >
+      Subscribe
+    </button>
+  </div>
+</body>
+`;
+
 exports[`SubscribeModal renders trigger button 1`] = `
 .c0 {
   display: flex;

--- a/apps/web/i18n/locales/en/blogPage.json
+++ b/apps/web/i18n/locales/en/blogPage.json
@@ -24,5 +24,7 @@
   "codeCopied": "Copied!",
   "share": "Share",
   "share.copyLink": "Copy link",
-  "share.copied": "Copied!"
+  "share.copied": "Copied!",
+  "likeButton.like": "Like this post",
+  "likeButton.liked": "Liked!"
 }

--- a/apps/web/i18n/locales/es/blogPage.json
+++ b/apps/web/i18n/locales/es/blogPage.json
@@ -24,5 +24,7 @@
   "codeCopied": "¡Copiado!",
   "share": "Compartir",
   "share.copyLink": "Copiar enlace",
-  "share.copied": "¡Copiado!"
+  "share.copied": "¡Copiado!",
+  "likeButton.like": "Me gusta este artículo",
+  "likeButton.liked": "¡Me gusta!"
 }

--- a/apps/web/lib/db/queries/posts.spec.ts
+++ b/apps/web/lib/db/queries/posts.spec.ts
@@ -20,6 +20,7 @@ import {
   getRelatedPosts,
   getScheduledPostsToPublish,
   hardDeletePost,
+  incrementPostLikes,
   restorePost,
   slugExistsForLocale,
   softDeletePost,
@@ -881,5 +882,19 @@ describe('getScheduledPostsToPublish', () => {
     })
     const result = await getScheduledPostsToPublish()
     expect(result[0].scheduledAt).toBe(date)
+  })
+})
+
+describe('incrementPostLikes', () => {
+  it('returns updated likes count', async () => {
+    mockDb.update.mockReturnValue(makeChain([{ likes: 5 }]))
+    const result = await incrementPostLikes('post-id')
+    expect(result).toBe(5)
+  })
+
+  it('returns 0 when no rows returned', async () => {
+    mockDb.update.mockReturnValue(makeChain([]))
+    const result = await incrementPostLikes('nonexistent')
+    expect(result).toBe(0)
   })
 })

--- a/apps/web/lib/db/queries/posts.ts
+++ b/apps/web/lib/db/queries/posts.ts
@@ -36,6 +36,7 @@ export type PublicPost = {
   seriesId: string | null
   seriesOrder: number | null
   seriesTitle: string | null
+  likes: number
   publishedAt: Date | null
   createdAt: Date
   updatedAt: Date
@@ -80,6 +81,7 @@ const publicFields = {
   seriesId: posts.seriesId,
   seriesOrder: posts.seriesOrder,
   seriesTitle: seriesTranslations.title,
+  likes: posts.likes,
   publishedAt: posts.publishedAt,
   createdAt: posts.createdAt,
   updatedAt: posts.updatedAt,
@@ -739,6 +741,15 @@ export async function getPublishedPostCountByCategory(
 export type ScheduledPost = {
   id: string
   scheduledAt: Date
+}
+
+export async function incrementPostLikes(postId: string): Promise<number> {
+  const rows = await db
+    .update(posts)
+    .set({ likes: sql`${posts.likes} + 1` })
+    .where(eq(posts.id, postId))
+    .returning({ likes: posts.likes })
+  return rows[0]?.likes ?? 0
 }
 
 export async function getScheduledPostsToPublish(): Promise<ScheduledPost[]> {

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -78,6 +78,7 @@ export const posts = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
+    likes: integer('likes').notNull().default(0),
     deletedAt: timestamp('deleted_at', { withTimezone: true }), // soft delete
     previewToken: text('preview_token').unique(),
   },

--- a/apps/web/lib/ratelimit/index.ts
+++ b/apps/web/lib/ratelimit/index.ts
@@ -8,3 +8,10 @@ export const ratelimit = redis
       limiter: Ratelimit.slidingWindow(10, '1m'),
     })
   : null
+
+export const likesRatelimit = redis
+  ? new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(1, '24h'),
+    })
+  : null

--- a/apps/web/proxy.spec.ts
+++ b/apps/web/proxy.spec.ts
@@ -130,6 +130,18 @@ describe('handleMiddleware', () => {
       expect(res).toBeUndefined()
     })
 
+    it('allows unauthenticated POST /api/posts/:id/like', async () => {
+      const req = makeReq('/api/posts/01KTS15Y8MWBG5WXWE2EJASF32/like', 'POST')
+      const res = await handleMiddleware(req)
+      expect(res).toBeUndefined()
+    })
+
+    it('allows unauthenticated POST /api/posts/:id/like with trailing slash', async () => {
+      const req = makeReq('/api/posts/01KTS15Y8MWBG5WXWE2EJASF32/like/', 'POST')
+      const res = await handleMiddleware(req)
+      expect(res).toBeUndefined()
+    })
+
     it('allows GET requests to /api/categories without auth', async () => {
       const req = makeReq('/api/categories', 'GET')
       const res = await handleMiddleware(req)

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -36,10 +36,12 @@ export async function handleMiddleware(
 
   const method = req.method
   const isWriteMethod = ['POST', 'PUT', 'DELETE'].includes(method)
+  const isLikeEndpoint = /^\/api\/posts\/[^/]+\/like\/?$/.test(pathname)
   const isProtectedApi =
-    pathname.startsWith('/api/posts') ||
-    pathname.startsWith('/api/categories') ||
-    pathname === '/api/upload'
+    !isLikeEndpoint &&
+    (pathname.startsWith('/api/posts') ||
+      pathname.startsWith('/api/categories') ||
+      pathname === '/api/upload')
 
   if (isProtectedApi && isWriteMethod && !isAuthenticated) {
     return new NextResponse('Unauthorized', { status: 401 })

--- a/libs/post-hero/src/lib/PostHero.spec.tsx
+++ b/libs/post-hero/src/lib/PostHero.spec.tsx
@@ -128,6 +128,21 @@ describe('PostHero', () => {
     expect(screen.queryByTestId('share-buttons')).not.toBeInTheDocument()
   })
 
+  it('renders actions when provided', () => {
+    renderWithTheme(
+      <PostHero
+        {...defaultProps}
+        actions={<button data-testid="hero-action">Like</button>}
+      />,
+    )
+    expect(screen.getByTestId('hero-action')).toBeInTheDocument()
+  })
+
+  it('does not render actions wrapper when actions not provided', () => {
+    renderWithTheme(<PostHero {...defaultProps} />)
+    expect(screen.queryByTestId('hero-action')).not.toBeInTheDocument()
+  })
+
   it('matches snapshot', () => {
     const { baseElement } = renderWithTheme(<PostHero {...defaultProps} />)
     expect(baseElement).toMatchSnapshot()

--- a/libs/post-hero/src/lib/PostHero.styles.ts
+++ b/libs/post-hero/src/lib/PostHero.styles.ts
@@ -91,6 +91,15 @@ export const StyledTag = styled.span`
   border-radius: 2px;
 `
 
+export const StyledMetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+`
+
 export const StyledMeta = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -99,7 +108,12 @@ export const StyledMeta = styled.div`
   color: ${({ theme }) => theme.colors.white};
   font-size: 0.875rem;
   opacity: 0.7;
-  margin-top: 0.75rem;
+`
+
+export const StyledMetaActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 `
 
 export const StyledMetaSep = styled.span`

--- a/libs/post-hero/src/lib/PostHero.tsx
+++ b/libs/post-hero/src/lib/PostHero.tsx
@@ -10,6 +10,8 @@ import {
   StyledHeader,
   StyledHeroContent,
   StyledMeta,
+  StyledMetaActions,
+  StyledMetaRow,
   StyledMetaSep,
   StyledPostTitle,
   StyledSeriesBadge,
@@ -34,6 +36,7 @@ export interface PostHeroProps {
   copyLinkLabel?: string
   copiedLabel?: string
   categoryIcon?: ReactNode
+  actions?: ReactNode
 }
 
 export function PostHero({
@@ -52,6 +55,7 @@ export function PostHero({
   copyLinkLabel,
   copiedLabel,
   categoryIcon,
+  actions,
 }: PostHeroProps) {
   return (
     <StyledHeader>
@@ -85,29 +89,32 @@ export function PostHero({
           ))}
         </StyledBadgeRow>
         <StyledPostTitle>{title}</StyledPostTitle>
-        <StyledMeta>
-          <span>{author}</span>
-          {publishedAt && (
-            <>
-              <StyledMetaSep aria-hidden>|</StyledMetaSep>
-              <time dateTime={publishedAt}>{publishedAt}</time>
-            </>
-          )}
-          <StyledMetaSep aria-hidden>|</StyledMetaSep>
-          <span data-testid="reading-time">{readingTime} min</span>
-          {url && (
-            <>
-              <StyledMetaSep aria-hidden>|</StyledMetaSep>
-              <ShareButtons
-                url={url}
-                title={title}
-                label={shareLabel}
-                copyLinkLabel={copyLinkLabel}
-                copiedLabel={copiedLabel}
-              />
-            </>
-          )}
-        </StyledMeta>
+        <StyledMetaRow>
+          <StyledMeta>
+            <span>{author}</span>
+            {publishedAt && (
+              <>
+                <StyledMetaSep aria-hidden>|</StyledMetaSep>
+                <time dateTime={publishedAt}>{publishedAt}</time>
+              </>
+            )}
+            <StyledMetaSep aria-hidden>|</StyledMetaSep>
+            <span data-testid="reading-time">{readingTime} min</span>
+            {url && (
+              <>
+                <StyledMetaSep aria-hidden>|</StyledMetaSep>
+                <ShareButtons
+                  url={url}
+                  title={title}
+                  label={shareLabel}
+                  copyLinkLabel={copyLinkLabel}
+                  copiedLabel={copiedLabel}
+                />
+              </>
+            )}
+          </StyledMeta>
+          {actions && <StyledMetaActions>{actions}</StyledMetaActions>}
+        </StyledMetaRow>
       </StyledHeroContent>
     </StyledHeader>
   )

--- a/libs/post-hero/src/lib/__snapshots__/PostHero.spec.tsx.snap
+++ b/libs/post-hero/src/lib/__snapshots__/PostHero.spec.tsx.snap
@@ -54,16 +54,24 @@ exports[`PostHero matches snapshot 1`] = `
 
 .c6 {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.c7 {
+  display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
   color: #FBFBFB;
   font-size: 0.875rem;
   opacity: 0.7;
-  margin-top: 0.75rem;
 }
 
-.c7 {
+.c8 {
   opacity: 0.35;
   user-select: none;
 }
@@ -129,32 +137,36 @@ exports[`PostHero matches snapshot 1`] = `
         <div
           class="c6"
         >
-          <span>
-            John Doe
-          </span>
-          <span
-            aria-hidden="true"
+          <div
             class="c7"
           >
-            |
-          </span>
-          <time
-            datetime="Jan 1, 2024"
-          >
-            Jan 1, 2024
-          </time>
-          <span
-            aria-hidden="true"
-            class="c7"
-          >
-            |
-          </span>
-          <span
-            data-testid="reading-time"
-          >
-            5
-             min
-          </span>
+            <span>
+              John Doe
+            </span>
+            <span
+              aria-hidden="true"
+              class="c8"
+            >
+              |
+            </span>
+            <time
+              datetime="Jan 1, 2024"
+            >
+              Jan 1, 2024
+            </time>
+            <span
+              aria-hidden="true"
+              class="c8"
+            >
+              |
+            </span>
+            <span
+              data-testid="reading-time"
+            >
+              5
+               min
+            </span>
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
…edup

Adds a heart like button per post with optimistic UI, server-side IP rate limiting via @upstash/ratelimit (1 like/IP/24h), and localStorage for client-side dedup. Moves like + subscribe actions to the post hero meta row opposite the share icons. Requires DB migration: ALTER TABLE posts ADD COLUMN likes INTEGER NOT NULL DEFAULT 0;

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Mandatory gif:

![](https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif)
