### PR TITLE
feat: show Watch on YouTube card for 360° videos instead of embedding

### DIFF
--- a/apps/web/app/admin/(auth)/posts/components/EmbedInsertModal/EmbedInsertModal.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/EmbedInsertModal/EmbedInsertModal.spec.tsx
@@ -249,6 +249,96 @@ describe('EmbedInsertModal initialValues', () => {
   })
 })
 
+describe('EmbedInsertModal 360°', () => {
+  it('shows 360 checkbox when embed type is youtube', () => {
+    renderApp(
+      <EmbedInsertModal isOpen onInsert={jest.fn()} onCancel={jest.fn()} />,
+    )
+    expect(screen.getByTestId('embed-is360-checkbox')).toBeInTheDocument()
+  })
+
+  it('hides 360 checkbox when embed type is maps', () => {
+    renderApp(
+      <EmbedInsertModal isOpen onInsert={jest.fn()} onCancel={jest.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('embed-type-maps'))
+    expect(screen.queryByTestId('embed-is360-checkbox')).not.toBeInTheDocument()
+  })
+
+  it('checking 360 updates preview to youtube-360 type', () => {
+    renderApp(
+      <EmbedInsertModal isOpen onInsert={jest.fn()} onCancel={jest.fn()} />,
+    )
+    fireEvent.change(screen.getByTestId('embed-url-input'), {
+      target: { value: 'https://www.youtube.com/embed/abc' },
+    })
+    fireEvent.click(screen.getByTestId('embed-is360-checkbox'))
+    expect(screen.getByTestId('embed-preview').textContent).toBe(
+      '```youtube-360\nhttps://www.youtube.com/embed/abc\n```',
+    )
+  })
+
+  it('inserts youtube-360 markdown when 360 checkbox is checked', () => {
+    const onInsert = jest.fn()
+    renderApp(
+      <EmbedInsertModal isOpen onInsert={onInsert} onCancel={jest.fn()} />,
+    )
+    fireEvent.change(screen.getByTestId('embed-url-input'), {
+      target: { value: 'https://www.youtube.com/embed/xyz' },
+    })
+    fireEvent.click(screen.getByTestId('embed-is360-checkbox'))
+    fireEvent.click(screen.getByTestId('embed-modal-insert'))
+    expect(onInsert).toHaveBeenCalledWith(
+      '\n\n```youtube-360\nhttps://www.youtube.com/embed/xyz\n```\n\n',
+    )
+  })
+
+  it('resets is360 after insert', () => {
+    renderApp(
+      <EmbedInsertModal isOpen onInsert={jest.fn()} onCancel={jest.fn()} />,
+    )
+    fireEvent.change(screen.getByTestId('embed-url-input'), {
+      target: { value: 'https://www.youtube.com/embed/xyz' },
+    })
+    fireEvent.click(screen.getByTestId('embed-is360-checkbox'))
+    fireEvent.click(screen.getByTestId('embed-modal-insert'))
+    expect(screen.getByTestId('embed-is360-checkbox')).not.toBeChecked()
+  })
+
+  it('switching away from youtube resets is360', () => {
+    renderApp(
+      <EmbedInsertModal isOpen onInsert={jest.fn()} onCancel={jest.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('embed-is360-checkbox'))
+    fireEvent.click(screen.getByTestId('embed-type-maps'))
+    fireEvent.click(screen.getByTestId('embed-type-youtube'))
+    expect(screen.getByTestId('embed-is360-checkbox')).not.toBeChecked()
+  })
+
+  it('initialValues with youtube-360 sets type to youtube and checks 360', () => {
+    const onInsert = jest.fn()
+    renderApp(
+      <EmbedInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        initialValues={{
+          type: 'youtube-360',
+          url: 'https://www.youtube.com/embed/abc123',
+        }}
+      />,
+    )
+    expect(screen.getByTestId('embed-is360-checkbox')).toBeChecked()
+    expect(screen.getByTestId('embed-url-input')).toHaveValue(
+      'https://www.youtube.com/embed/abc123',
+    )
+    fireEvent.click(screen.getByTestId('embed-modal-insert'))
+    expect(onInsert).toHaveBeenCalledWith(
+      '\n\n```youtube-360\nhttps://www.youtube.com/embed/abc123\n```\n\n',
+    )
+  })
+})
+
 describe('buildEmbedMarkdown', () => {
   it('builds youtube markdown', () => {
     expect(

--- a/apps/web/app/admin/(auth)/posts/components/EmbedInsertModal/EmbedInsertModal.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/EmbedInsertModal/EmbedInsertModal.styles.ts
@@ -118,6 +118,19 @@ export const StyledPreview = styled.pre`
   word-break: break-all;
 `
 
+export const StyledCheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`
+
+export const StyledCheckboxLabel = styled.label`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.7;
+  cursor: pointer;
+`
+
 export const StyledButtons = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/apps/web/app/admin/(auth)/posts/components/EmbedInsertModal/EmbedInsertModal.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/EmbedInsertModal/EmbedInsertModal.tsx
@@ -8,6 +8,8 @@ import {
   StyledBackdrop,
   StyledButtons,
   StyledCancelButton,
+  StyledCheckboxLabel,
+  StyledCheckboxRow,
   StyledEmbedInsertModal,
   StyledInput,
   StyledInsertButton,
@@ -44,7 +46,7 @@ const PLACEHOLDERS: Record<EmbedType, string> = {
     'https://www.wikiloc.com/wikiloc/embedv2.do?id=<trail-id>&elevation=on&images=on&maptype=H',
 }
 
-export function buildEmbedMarkdown(type: EmbedType, url: string): string {
+export function buildEmbedMarkdown(type: string, url: string): string {
   return `\n\n\`\`\`${type}\n${url.trim()}\n\`\`\`\n\n`
 }
 
@@ -55,19 +57,31 @@ export function EmbedInsertModal({
   initialValues,
 }: EmbedInsertModalProps) {
   const [embedType, setEmbedType] = useState<EmbedType>(
-    initialValues?.type ?? 'youtube',
+    initialValues?.type === 'youtube-360'
+      ? 'youtube'
+      : (initialValues?.type ?? 'youtube'),
   )
   const [url, setUrl] = useState(initialValues?.url ?? '')
+  const [is360, setIs360] = useState(initialValues?.type === 'youtube-360')
+
+  function handleTypeChange(type: EmbedType) {
+    setEmbedType(type)
+    if (type !== 'youtube') setIs360(false)
+  }
 
   function handleInsert() {
     /* istanbul ignore next */
     if (!url.trim()) return
-    onInsert(buildEmbedMarkdown(embedType, url))
+    const finalType =
+      embedType === 'youtube' && is360 ? 'youtube-360' : embedType
+    onInsert(buildEmbedMarkdown(finalType, url))
     setEmbedType('youtube')
     setUrl('')
+    setIs360(false)
   }
 
-  const preview = url.trim() ? buildEmbedMarkdown(embedType, url).trim() : null
+  const finalType = embedType === 'youtube' && is360 ? 'youtube-360' : embedType
+  const preview = url.trim() ? buildEmbedMarkdown(finalType, url).trim() : null
 
   return (
     <StyledEmbedInsertModal
@@ -86,7 +100,7 @@ export function EmbedInsertModal({
               key={type}
               type="button"
               $active={embedType === type}
-              onClick={() => setEmbedType(type)}
+              onClick={() => handleTypeChange(type)}
               data-testid={`embed-type-${type}`}
             >
               {LABELS[type]}
@@ -103,6 +117,21 @@ export function EmbedInsertModal({
           placeholder={PLACEHOLDERS[embedType]}
           data-testid="embed-url-input"
         />
+
+        {embedType === 'youtube' && (
+          <StyledCheckboxRow>
+            <input
+              id="embed-is360"
+              type="checkbox"
+              checked={is360}
+              onChange={(e) => setIs360(e.target.checked)}
+              data-testid="embed-is360-checkbox"
+            />
+            <StyledCheckboxLabel htmlFor="embed-is360">
+              360° video (links to YouTube instead of embedding)
+            </StyledCheckboxLabel>
+          </StyledCheckboxRow>
+        )}
 
         {preview && (
           <StyledPreview data-testid="embed-preview">{preview}</StyledPreview>

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.ts
@@ -1,4 +1,9 @@
-export type EmbedType = 'youtube' | 'maps' | 'openstreetmap' | 'wikiloc'
+export type EmbedType =
+  | 'youtube'
+  | 'youtube-360'
+  | 'maps'
+  | 'openstreetmap'
+  | 'wikiloc'
 
 export interface ParsedImage {
   url: string
@@ -35,7 +40,13 @@ export type DetectedEmbed =
   | { type: 'embed'; blockStart: number; blockEnd: number; parsed: ParsedEmbed }
   | { type: 'gpx'; blockStart: number; blockEnd: number; parsed: ParsedGpx }
 
-const EMBED_TYPES: EmbedType[] = ['youtube', 'maps', 'openstreetmap', 'wikiloc']
+const EMBED_TYPES: EmbedType[] = [
+  'youtube',
+  'youtube-360',
+  'maps',
+  'openstreetmap',
+  'wikiloc',
+]
 
 function parseImageParams(params: string): Omit<ParsedImage, 'url'> {
   const result: Omit<ParsedImage, 'url'> = {
@@ -183,7 +194,7 @@ export function detectEmbedAtCursor(
   }
 
   // Code fence blocks: ```type\n...\n```
-  const fenceRe = /```([a-z]+)\n([\s\S]*?)```/g
+  const fenceRe = /```([a-z0-9-]+)\n([\s\S]*?)```/g
   while ((m = fenceRe.exec(content)) !== null) {
     const { index } = m
     const blockEnd = index + m[0].length

--- a/apps/web/components/PostContent/PostContent.styles.ts
+++ b/apps/web/components/PostContent/PostContent.styles.ts
@@ -302,3 +302,75 @@ export const StyledEmbedWrapper = styled.div`
     border: none;
   }
 `
+
+export const StyledEmbed360Wrapper = styled.div`
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  height: 0;
+  margin: 2rem 0;
+  border-radius: 2px;
+  overflow: hidden;
+  background: #000;
+`
+
+export const StyledEmbed360Thumbnail = styled.img`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.4;
+`
+
+export const StyledEmbed360Overlay = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  text-align: center;
+`
+
+export const StyledEmbed360Badge = styled.span`
+  font-family: var(--font-roboto-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: ${({ theme }) => theme.colors.orange};
+  border: 1px solid ${({ theme }) => theme.colors.orange};
+  border-radius: 2px;
+  padding: 0.2rem 0.6rem;
+`
+
+export const StyledEmbed360Info = styled.p`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.7;
+  margin: 0;
+  max-width: 32rem;
+`
+
+export const StyledEmbed360Link = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.white};
+  background: #ff0000;
+  border-radius: 2px;
+  padding: 0.45rem 1rem;
+  text-decoration: none !important;
+  transition: opacity 0.15s;
+
+  &:hover {
+    opacity: 0.85;
+    color: ${({ theme }) => theme.colors.white};
+    text-decoration: none !important;
+  }
+`

--- a/apps/web/components/PostContent/PostContentEmbed.spec.tsx
+++ b/apps/web/components/PostContent/PostContentEmbed.spec.tsx
@@ -12,6 +12,8 @@ jest.mock('@web/i18n/client', () => ({
         'gpxMap.colCoordinates': 'Coordinates',
         'gpxMap.colElevation': 'Elevation',
         'gpxMap.flyTo': 'View on map',
+        'embed.watchOnYouTube': 'Watch on YouTube',
+        'embed.360info': '360 info text',
       }
       return map[key] ?? key
     },
@@ -21,6 +23,40 @@ jest.mock('@web/i18n/client', () => ({
 jest.mock('./PostContent.styles', () => ({
   StyledEmbedWrapper: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="post-embed-wrapper">{children}</div>
+  ),
+  StyledEmbed360Wrapper: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  StyledEmbed360Thumbnail: ({
+    src,
+    alt,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img
+      src={src}
+      alt={alt}
+      data-testid="post-embed-360-thumbnail"
+      {...props}
+    />
+  ),
+  StyledEmbed360Overlay: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  StyledEmbed360Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  StyledEmbed360Info: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  StyledEmbed360Link: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} data-testid="post-embed-360-link" {...props}>
+      {children}
+    </a>
   ),
 }))
 
@@ -220,5 +256,42 @@ describe('PostContentEmbed', () => {
       'data-waypoint-images',
       JSON.stringify(images),
     )
+  })
+
+  it('renders 360 card with thumbnail and watch link for youtube-360 type', () => {
+    render(
+      <PostContentEmbed
+        type="youtube-360"
+        url="https://www.youtube.com/embed/abc123"
+      />,
+    )
+    expect(screen.getByTestId('post-embed-360-wrapper')).toBeInTheDocument()
+    const thumbnail = screen.getByTestId('post-embed-360-thumbnail')
+    expect(thumbnail).toHaveAttribute(
+      'src',
+      'https://img.youtube.com/vi/abc123/hqdefault.jpg',
+    )
+    const link = screen.getByTestId('post-embed-360-link')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.youtube.com/watch?v=abc123',
+    )
+    expect(link).toHaveTextContent('Watch on YouTube')
+    expect(screen.getByText('360 info text')).toBeInTheDocument()
+  })
+
+  it('renders 360 card without thumbnail when url has no youtube video id', () => {
+    render(
+      <PostContentEmbed
+        type="youtube-360"
+        url="https://example.com/not-youtube"
+      />,
+    )
+    expect(screen.getByTestId('post-embed-360-wrapper')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('post-embed-360-thumbnail'),
+    ).not.toBeInTheDocument()
+    const link = screen.getByTestId('post-embed-360-link')
+    expect(link).toHaveAttribute('href', 'https://example.com/not-youtube')
   })
 })

--- a/apps/web/components/PostContent/PostContentEmbed.tsx
+++ b/apps/web/components/PostContent/PostContentEmbed.tsx
@@ -6,7 +6,15 @@ import type { GpxTrackDef } from '@sdlgr/gpx-map'
 
 import { useClientTranslation } from '@web/i18n/client'
 
-import { StyledEmbedWrapper } from './PostContent.styles'
+import {
+  StyledEmbed360Badge,
+  StyledEmbed360Info,
+  StyledEmbed360Link,
+  StyledEmbed360Overlay,
+  StyledEmbed360Thumbnail,
+  StyledEmbed360Wrapper,
+  StyledEmbedWrapper,
+} from './PostContent.styles'
 
 const GpxMap = dynamic(
   () => import('@sdlgr/gpx-map').then((m) => ({ default: m.GpxMap })),
@@ -60,6 +68,35 @@ export function PostContentEmbed({
   }
 
   if (!url) return null
+
+  if (type === 'youtube-360') {
+    const videoId = url.match(/youtube\.com\/embed\/([^?&/]+)/)?.[1] ?? null
+    const watchUrl = videoId
+      ? `https://www.youtube.com/watch?v=${videoId}`
+      : url
+    const thumbnailUrl = videoId
+      ? `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`
+      : null
+
+    return (
+      <StyledEmbed360Wrapper data-testid="post-embed-360-wrapper">
+        {thumbnailUrl && (
+          <StyledEmbed360Thumbnail src={thumbnailUrl} alt="" aria-hidden />
+        )}
+        <StyledEmbed360Overlay>
+          <StyledEmbed360Badge>360°</StyledEmbed360Badge>
+          <StyledEmbed360Info>{t('embed.360info')}</StyledEmbed360Info>
+          <StyledEmbed360Link
+            href={watchUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t('embed.watchOnYouTube')}
+          </StyledEmbed360Link>
+        </StyledEmbed360Overlay>
+      </StyledEmbed360Wrapper>
+    )
+  }
 
   return (
     <StyledEmbedWrapper data-testid="post-embed-wrapper">

--- a/apps/web/i18n/locales/en/common.json
+++ b/apps/web/i18n/locales/en/common.json
@@ -20,5 +20,9 @@
     "iso": "ISO",
     "aperture": "Aperture",
     "exposure": "Exposure"
+  },
+  "embed": {
+    "watchOnYouTube": "Watch on YouTube",
+    "360info": "360° videos must be watched directly on YouTube — embedded players don't support interactive 360° viewing."
   }
 }

--- a/apps/web/i18n/locales/es/common.json
+++ b/apps/web/i18n/locales/es/common.json
@@ -20,5 +20,9 @@
     "iso": "ISO",
     "aperture": "Apertura",
     "exposure": "Exposición"
+  },
+  "embed": {
+    "watchOnYouTube": "Ver en YouTube",
+    "360info": "Los vídeos 360° deben verse directamente en YouTube — los reproductores integrados no admiten la visualización 360° interactiva."
   }
 }

--- a/apps/web/lib/mdx/remarkEmbeds.ts
+++ b/apps/web/lib/mdx/remarkEmbeds.ts
@@ -1,4 +1,11 @@
-const EMBED_LANGS = ['youtube', 'maps', 'wikiloc', 'openstreetmap', 'gpx']
+const EMBED_LANGS = [
+  'youtube',
+  'youtube-360',
+  'maps',
+  'wikiloc',
+  'openstreetmap',
+  'gpx',
+]
 
 export interface TrackDef {
   url: string


### PR DESCRIPTION
YouTube's embedded player no longer supports interactive 360° viewing. Adds a youtube-360 embed type that renders a thumbnail + info card with a direct YouTube watch link instead of an iframe.

- Admin embed modal gains a 360° checkbox (YouTube type only)
- parseEmbedBlock and remarkEmbeds recognise youtube-360 fence type
- PostContentEmbed renders styled card with badge, info text, and link
- i18n strings added for en and es

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Mandatory gif:

![](https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif)
