### PR TITLE
feat: revalidate post static pages on update

### DIFF
--- a/apps/web/app/api/posts/[id]/route.spec.ts
+++ b/apps/web/app/api/posts/[id]/route.spec.ts
@@ -16,10 +16,14 @@ const mockUpsertSeriesTranslation = jest.fn()
 const mockSeriesOrderExistsForSeries = jest.fn()
 
 const mockRevalidateTag = jest.fn()
+const mockRevalidatePath = jest.fn()
 const mockLoggerError = jest.fn()
 const mockNotifyPostPublished = jest.fn()
 
-jest.mock('next/cache', () => ({ revalidateTag: mockRevalidateTag }))
+jest.mock('next/cache', () => ({
+  revalidateTag: mockRevalidateTag,
+  revalidatePath: mockRevalidatePath,
+}))
 jest.mock('@web/lib/email/notifyPostPublished', () => ({
   notifyPostPublished: mockNotifyPostPublished,
 }))
@@ -69,6 +73,7 @@ const { DELETE, GET, PUT } = require('./route') as {
 
 const mockPost = {
   id: '01JWTEST000000000000000000',
+  postNumber: 42,
   category: 'engineering',
   tags: [],
   status: 'draft',
@@ -214,6 +219,7 @@ describe('PUT /api/posts/[id]', () => {
     jest.clearAllMocks()
     mockGetPostStatus.mockResolvedValue('draft')
     mockNotifyPostPublished.mockResolvedValue(undefined)
+    mockGetPostTranslations.mockResolvedValue([])
   })
 
   it('returns 401 when not authenticated', async () => {
@@ -426,6 +432,26 @@ describe('PUT /api/posts/[id]', () => {
       'post-01JWTEST000000000000000000',
       'default',
     )
+  })
+
+  it('calls revalidatePath for each translation after update', async () => {
+    mockAuth.mockResolvedValue({ user: { name: 'admin' } })
+    mockUpdatePost.mockResolvedValue({ ...mockPost, postNumber: 42 })
+    mockGetPostTranslations.mockResolvedValue([
+      { locale: 'en', slug: 'my-post' },
+      { locale: 'es', slug: 'mi-post' },
+    ])
+    await PUT(makePutRequest({ tags: ['react'] }), makeParams('id'))
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/en/blog/42/my-post')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/es/blog/42/mi-post')
+  })
+
+  it('does not call revalidatePath when post has no translations', async () => {
+    mockAuth.mockResolvedValue({ user: { name: 'admin' } })
+    mockUpdatePost.mockResolvedValue(mockPost)
+    mockGetPostTranslations.mockResolvedValue([])
+    await PUT(makePutRequest({ tags: ['react'] }), makeParams('id'))
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
   })
 
   it('upserts translations when provided', async () => {

--- a/apps/web/app/api/posts/[id]/route.ts
+++ b/apps/web/app/api/posts/[id]/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -230,6 +230,10 @@ export async function PUT(
     }
 
     logger.info({ id, status: data.status }, 'PUT /api/posts/[id]: updated')
+    const updatedTranslations = await getPostTranslations(id)
+    for (const t of updatedTranslations) {
+      revalidatePath(`/${t.locale}/blog/${post.postNumber}/${t.slug}`)
+    }
     revalidateTag('posts', 'default')
     revalidateTag(`post-${id}`, 'default')
     return NextResponse.json(post)


### PR DESCRIPTION
Calls revalidatePath for each locale after a post is updated so the statically generated blog pages reflect content changes immediately instead of waiting for the 1h ISR interval.

The page uses direct DB queries rather than tagged fetches, so the existing revalidateTag calls were not invalidating the static pages.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Mandatory gif:

![](https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif)
