### PR TITLE
fix: 360° card clipped on mobile

### DIFF
--- a/apps/web/components/PostContent/PostContent.styles.ts
+++ b/apps/web/components/PostContent/PostContent.styles.ts
@@ -306,8 +306,8 @@ export const StyledEmbedWrapper = styled.div`
 export const StyledEmbed360Wrapper = styled.div`
   position: relative;
   width: 100%;
-  padding-bottom: 56.25%;
-  height: 0;
+  aspect-ratio: 16 / 9;
+  min-height: 300px;
   margin: 2rem 0;
   border-radius: 2px;
   overflow: hidden;
@@ -333,6 +333,11 @@ export const StyledEmbed360Overlay = styled.div`
   gap: 0.75rem;
   padding: 1.5rem;
   text-align: center;
+
+  @media (max-width: 640px) {
+    gap: 0.5rem;
+    padding: 1rem;
+  }
 `
 
 export const StyledEmbed360Badge = styled.span`


### PR DESCRIPTION
Switch from padding-bottom aspect-ratio trick to aspect-ratio + min-height so the card grows tall enough on narrow screens to show all content. Tighten overlay gap/padding on mobile via media query.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Mandatory gif:

![](https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif)
