### PR TITLE
fix: prevent static-to-dynamic error on blog preview pages

### DIFF
--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -1,6 +1,7 @@
 import { format } from 'date-fns'
 import { Locale as DateLocale, enUS, es } from 'date-fns/locale'
 import { notFound, redirect } from 'next/navigation'
+import { connection } from 'next/server'
 
 import { PostHero } from '@sdlgr/post-hero'
 import { TableOfContents } from '@sdlgr/table-of-contents'
@@ -149,6 +150,7 @@ export default async function BlogPostPage({ params }: RouteProps) {
   if (!post) return notFound()
   const isPreview = post.status !== 'published'
   if (isPreview) {
+    await connection()
     const session = await auth()
     if (!session) return notFound()
   }

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
@@ -8,6 +8,10 @@ jest.mock('next/navigation', () => ({
   redirect: mockRedirect,
 }))
 
+jest.mock('next/server', () => ({
+  connection: jest.fn().mockResolvedValue(undefined),
+}))
+
 const mockGetPostByNumber = jest.fn()
 const mockGetPublishedPosts = jest.fn()
 

--- a/apps/web/components/PostComments/PostComments.spec.tsx
+++ b/apps/web/components/PostComments/PostComments.spec.tsx
@@ -11,9 +11,11 @@ jest.mock('axios', () => ({
 
 jest.mock('@web/i18n/client', () => ({
   useClientTranslation: jest.fn().mockReturnValue({
-    t: jest.fn((key: string, opts?: { username?: string }) =>
-      opts?.username ? `Reply to ${opts.username}` : key,
-    ),
+    t: jest.fn((key: string, opts?: { username?: string }) => {
+      if (opts?.username) return `Reply to ${opts.username}`
+      if (key === 'comments.reply') return '↳ Reply'
+      return key
+    }),
   }),
 }))
 

--- a/apps/web/components/PostComments/PostComments.tsx
+++ b/apps/web/components/PostComments/PostComments.tsx
@@ -148,7 +148,7 @@ export function PostComments({
                 onClick={() => handleReply(comment.id, comment.username)}
                 data-testid="reply-button"
               >
-                ↳ reply
+                {t('comments.reply')}
               </StyledReplyButton>
 
               {comment.replies.length > 0 && (
@@ -182,7 +182,7 @@ export function PostComments({
                         onClick={() => handleReply(reply.id, reply.username)}
                         data-testid="reply-button"
                       >
-                        ↳ reply
+                        {t('comments.reply')}
                       </StyledReplyButton>
                     </StyledCommentItem>
                   ))}

--- a/apps/web/i18n/locales/en/blogPage.json
+++ b/apps/web/i18n/locales/en/blogPage.json
@@ -39,6 +39,7 @@
   "comments.form.error": "Something went wrong, please try again.",
   "comments.error": "Failed to load comments.",
   "comments.disabled": "Comments are disabled for this post.",
+  "comments.reply": "↳ Reply",
   "comments.replyTo": "Reply to {{username}}",
   "preview.banner": "Admin preview — this post is not publicly visible"
 }

--- a/apps/web/i18n/locales/es/blogPage.json
+++ b/apps/web/i18n/locales/es/blogPage.json
@@ -39,6 +39,7 @@
   "comments.form.error": "Algo salió mal, por favor inténtalo de nuevo.",
   "comments.error": "No se pudieron cargar los comentarios.",
   "comments.disabled": "Los comentarios están desactivados para esta publicación.",
+  "comments.reply": "↳ Responder",
   "comments.replyTo": "Responder a {{username}}",
   "preview.banner": "Vista previa — esta publicación no es visible públicamente"
 }


### PR DESCRIPTION
## Summary

- Add `connection()` from `next/server` before `auth()` in the blog post page's `isPreview` branch, fixing the production error: _"Page changed from static to dynamic at runtime, reason: headers"_
- Published posts remain fully static/ISR — only admin draft previews opt into dynamic rendering
- Translate hardcoded `↳ reply` button text in `PostComments` using `comments.reply` i18n key (en + es)

## Test plan

- [ ] Open a published blog post — should still be served from ISR cache (no change)
- [ ] Open a draft post as admin — should render without the static-to-dynamic error
- [ ] Open a draft post without a session — should return 404
- [ ] Reply button text renders in English (`↳ Reply`) and Spanish (`↳ Responder`)
- [ ] All 2128 tests pass, 100% coverage