### PR TITLE
fix: use token-based preview route for draft posts

### DIFF
--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.next.tsx
@@ -1,7 +1,6 @@
 import { format } from 'date-fns'
 import { Locale as DateLocale, enUS, es } from 'date-fns/locale'
 import { notFound, redirect } from 'next/navigation'
-import { connection } from 'next/server'
 
 import { PostHero } from '@sdlgr/post-hero'
 import { TableOfContents } from '@sdlgr/table-of-contents'
@@ -10,12 +9,10 @@ import { JsonLd } from '@web/components/JsonLd/JsonLd'
 import { PostComments } from '@web/components/PostComments'
 import { PostContent } from '@web/components/PostContent/PostContent'
 import { PostLikeButton } from '@web/components/PostLikeButton'
-import { PreviewBanner } from '@web/components/PreviewBanner'
 import { RelatedPosts } from '@web/components/RelatedPosts/RelatedPosts'
 import { SeriesIndicator } from '@web/components/SeriesIndicator/SeriesIndicator'
 import { SubscribeModal } from '@web/components/SubscribeModal'
 import { getServerTranslation } from '@web/i18n/server'
-import { auth } from '@web/lib/auth/config'
 import { getCategoryTranslations } from '@web/lib/db/queries/categories'
 import { getPostByNumber, getPublishedPosts } from '@web/lib/db/queries/posts'
 import { Locale } from '@web/lib/db/schema'
@@ -147,13 +144,7 @@ export default async function BlogPostPage({ params }: RouteProps) {
   const postNumber = parseInt(id, 10)
   if (isNaN(postNumber)) return notFound()
   const post = await getPostByNumber(postNumber, lng as Locale)
-  if (!post) return notFound()
-  const isPreview = post.status !== 'published'
-  if (isPreview) {
-    await connection()
-    const session = await auth()
-    if (!session) return notFound()
-  }
+  if (!post || post.status !== 'published') return notFound()
   if (post.slug !== slug)
     return redirect(`/${lng}/blog/${post.postNumber}/${post.slug}`)
 
@@ -170,7 +161,6 @@ export default async function BlogPostPage({ params }: RouteProps) {
 
   return (
     <StyledPage>
-      {isPreview && <PreviewBanner label={t('preview.banner')} />}
       <JsonLd data={generateArticleJsonLd(post, lng, postUrl)} />
       <PostHero
         title={post.title}

--- a/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
+++ b/apps/web/app/[lng]/blog/[id]/[slug]/page.spec.tsx
@@ -8,10 +8,6 @@ jest.mock('next/navigation', () => ({
   redirect: mockRedirect,
 }))
 
-jest.mock('next/server', () => ({
-  connection: jest.fn().mockResolvedValue(undefined),
-}))
-
 const mockGetPostByNumber = jest.fn()
 const mockGetPublishedPosts = jest.fn()
 
@@ -114,17 +110,6 @@ jest.mock('@web/components/PostLikeButton', () => ({
   PostLikeButton: () => <div data-testid="post-like-button" />,
 }))
 
-jest.mock('@web/components/PreviewBanner', () => ({
-  PreviewBanner: ({ label }: { label: string }) => (
-    <div data-testid="preview-banner">{label}</div>
-  ),
-}))
-
-const mockAuth = jest.fn()
-jest.mock('@web/lib/auth/config', () => ({
-  auth: () => mockAuth(),
-}))
-
 const publishedPost = {
   id: '01JXYZ',
   postNumber: 1,
@@ -152,7 +137,6 @@ describe('[lng]/blog/[id]/[slug] - BlogPostPage', () => {
     jest.clearAllMocks()
     mockPostHero.mockReturnValue(<div data-testid="post-hero" />)
     mockPostComments.mockReturnValue(<div data-testid="post-comments" />)
-    mockAuth.mockResolvedValue(null)
     mockGetServerTranslation.mockResolvedValue({ t: (key: string) => key })
     mockGetCategoryTranslations.mockResolvedValue([
       {
@@ -197,27 +181,6 @@ describe('[lng]/blog/[id]/[slug] - BlogPostPage', () => {
       params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
     })
     expect(mockNotFound).toHaveBeenCalledTimes(1)
-  })
-
-  it('shows PreviewBanner when admin views a draft post', async () => {
-    mockAuth.mockResolvedValue({ user: { role: 'admin' } })
-    mockGetPostByNumber.mockResolvedValue({ ...publishedPost, status: 'draft' })
-    const { default: BlogPostPage } = require('./page.next')
-    const ui = await BlogPostPage({
-      params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
-    })
-    render(ui)
-    expect(screen.getByTestId('preview-banner')).toBeInTheDocument()
-  })
-
-  it('does not show PreviewBanner for published post', async () => {
-    mockGetPostByNumber.mockResolvedValue(publishedPost)
-    const { default: BlogPostPage } = require('./page.next')
-    const ui = await BlogPostPage({
-      params: Promise.resolve({ lng: 'en', id: '1', slug: 'my-test-post' }),
-    })
-    render(ui)
-    expect(screen.queryByTestId('preview-banner')).not.toBeInTheDocument()
   })
 
   it('calls redirect when slug does not match', async () => {

--- a/apps/web/app/admin/(auth)/posts/[id]/page.next.tsx
+++ b/apps/web/app/admin/(auth)/posts/[id]/page.next.tsx
@@ -50,6 +50,8 @@ export default async function EditPostPage({ params }: EditPostPageProps) {
       seriesOrder: postData.post.seriesOrder,
       scheduledAt: postData.post.scheduledAt,
       authorId: postData.post.authorId,
+      commentsEnabled: postData.post.commentsEnabled,
+      previewToken: postData.post.previewToken,
     },
     translations: postData.translations.map((t) => ({
       locale: t.locale,

--- a/apps/web/app/admin/(auth)/posts/[id]/page.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/[id]/page.spec.tsx
@@ -81,6 +81,7 @@ const mockPostData = {
     seriesId: null,
     seriesOrder: null,
     authorId: 'user-1',
+    commentsEnabled: true,
     scheduledAt: null,
     publishedAt: null,
     createdAt: new Date('2024-01-01'),

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.edit.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.edit.spec.tsx
@@ -350,6 +350,8 @@ const mockExistingPost: PostEditorProps['post'] = {
     seriesOrder: 2,
     scheduledAt: null,
     authorId: 'user-1',
+    commentsEnabled: true,
+    previewToken: 'preview-tok',
   },
   translations: [
     {
@@ -1016,7 +1018,7 @@ describe('PostEditor', () => {
       expect(screen.getByTestId('draft-preview-row')).toBeInTheDocument()
       expect(screen.getByTestId('draft-preview-link')).toHaveAttribute(
         'href',
-        '/en/blog/7/my-post',
+        '/blog/preview/preview-tok',
       )
     })
 
@@ -1034,12 +1036,12 @@ describe('PostEditor', () => {
       expect(screen.queryByTestId('draft-preview-row')).not.toBeInTheDocument()
     })
 
-    it('does not show draft preview row when postNumber is null', () => {
+    it('does not show draft preview row when previewToken is null', () => {
       renderApp(
         <PostEditor
           post={{
             ...mockExistingPost,
-            post: { ...mockExistingPost.post, postNumber: null },
+            post: { ...mockExistingPost.post, previewToken: null },
           }}
           categories={mockCategories}
           users={mockUsers}
@@ -1060,7 +1062,7 @@ describe('PostEditor', () => {
       fireEvent.click(screen.getByTestId('draft-preview-copy-button'))
       await waitFor(() => {
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-          expect.stringContaining('/en/blog/7/my-post'),
+          expect.stringContaining('/blog/preview/preview-tok'),
         )
       })
       await waitFor(() => {

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.spec.tsx
@@ -457,6 +457,7 @@ const mockExistingPost: PostEditorProps['post'] = {
     scheduledAt: null,
     authorId: 'user-1',
     commentsEnabled: true,
+    previewToken: 'preview-tok',
   },
   translations: [
     {

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
@@ -129,6 +129,7 @@ export interface PostEditorPost {
   scheduledAt: Date | null
   authorId: string | null
   commentsEnabled: boolean
+  previewToken: string | null
 }
 
 export type PostEditorSeries = {
@@ -451,11 +452,8 @@ export function PostEditor({
   const previewAuthor = users.find((u) => u.id === editAuthor)?.name ?? ''
 
   const draftPreviewPath =
-    post &&
-    status !== 'published' &&
-    post.post.postNumber != null &&
-    currentLocale.slug
-      ? `/${activeLocale}/blog/${post.post.postNumber}/${currentLocale.slug}`
+    post && status !== 'published' && post.post.previewToken
+      ? `/blog/preview/${post.post.previewToken}`
       : null
 
   function handleCopyPreviewUrl() {

--- a/apps/web/app/blog/preview/[token]/layout.next.tsx
+++ b/apps/web/app/blog/preview/[token]/layout.next.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react'
+
+import { LanguageContextProvider } from '@sdlgr/i18n-tools'
+import { robotoMonoClassName } from '@sdlgr/main-theme'
+
+import { MainLayout } from '@web/components/MainLayout/MainLayout'
+import StyledComponentsRegistry from '@web/components/StyledComponentsRegistry/StyledComponentsRegistry'
+
+import '../../../globals.css'
+
+export default function PreviewLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className={robotoMonoClassName}>
+      <body>
+        <StyledComponentsRegistry>
+          <LanguageContextProvider value={{ language: 'en' }}>
+            <MainLayout>{children}</MainLayout>
+          </LanguageContextProvider>
+        </StyledComponentsRegistry>
+      </body>
+    </html>
+  )
+}

--- a/apps/web/app/blog/preview/[token]/layout.spec.tsx
+++ b/apps/web/app/blog/preview/[token]/layout.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+
+import PreviewLayout from './layout.next'
+
+jest.mock('@sdlgr/i18n-tools', () => ({
+  LanguageContextProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}))
+
+jest.mock('@sdlgr/main-theme', () => ({
+  robotoMonoClassName: 'roboto-mono',
+}))
+
+jest.mock('@web/components/MainLayout/MainLayout', () => ({
+  MainLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="main-layout">{children}</div>
+  ),
+}))
+
+jest.mock(
+  '@web/components/StyledComponentsRegistry/StyledComponentsRegistry',
+  () =>
+    ({ children }: { children: React.ReactNode }) =>
+      children,
+)
+
+jest.mock('../../../globals.css', () => ({}))
+
+describe('blog/preview/[token] - PreviewLayout', () => {
+  it('renders children inside main layout', () => {
+    render(<PreviewLayout>content</PreviewLayout>)
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument()
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('sets html lang to en', () => {
+    render(<PreviewLayout>content</PreviewLayout>)
+    expect(document.documentElement.lang).toBe('en')
+  })
+})

--- a/apps/web/app/blog/preview/[token]/page.next.styles.ts
+++ b/apps/web/app/blog/preview/[token]/page.next.styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+export const StyledPage = styled.main`
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 1rem 4rem;
+
+  @media (width >= 1024px) {
+    padding: 0 2rem 5rem;
+  }
+`

--- a/apps/web/app/blog/preview/[token]/page.next.tsx
+++ b/apps/web/app/blog/preview/[token]/page.next.tsx
@@ -3,10 +3,13 @@ import { notFound } from 'next/navigation'
 
 import { PostHero } from '@sdlgr/post-hero'
 
-import StyledComponentsRegistry from '@web/components/StyledComponentsRegistry/StyledComponentsRegistry'
+import { PostContent } from '@web/components/PostContent/PostContent'
+import { PreviewBanner } from '@web/components/PreviewBanner'
 import { getPostByPreviewToken } from '@web/lib/db/queries/posts'
 import { renderMDX } from '@web/lib/mdx/renderMDX'
 import { computeReadingTime } from '@web/utils/computeReadingTime'
+
+import { StyledPage } from './page.next.styles'
 
 interface RouteProps {
   params: Promise<{ token: string }>
@@ -31,20 +34,18 @@ export default async function PreviewPage({ params }: RouteProps) {
   if (!translation) return notFound()
 
   return (
-    <StyledComponentsRegistry>
-      <main>
-        <div data-testid="preview-banner">PREVIEW MODE</div>
-        <PostHero
-          title={translation.title}
-          coverImagePublicId={post.coverImage}
-          category={post.category}
-          author={authorName}
-          publishedAt={null}
-          readingTime={computeReadingTime(translation.content)}
-          lng={lng}
-        />
-        <article>{renderMDX(translation.content)}</article>
-      </main>
-    </StyledComponentsRegistry>
+    <StyledPage>
+      <PreviewBanner label="Admin preview — this post is not publicly visible" />
+      <PostHero
+        title={translation.title}
+        coverImagePublicId={post.coverImage}
+        category={post.category}
+        author={authorName}
+        publishedAt={null}
+        readingTime={computeReadingTime(translation.content)}
+        lng={lng}
+      />
+      <PostContent>{renderMDX(translation.content)}</PostContent>
+    </StyledPage>
   )
 }

--- a/apps/web/app/blog/preview/[token]/page.next.tsx
+++ b/apps/web/app/blog/preview/[token]/page.next.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 
 import { PostHero } from '@sdlgr/post-hero'
 
+import { PostComments } from '@web/components/PostComments'
 import { PostContent } from '@web/components/PostContent/PostContent'
 import { PreviewBanner } from '@web/components/PreviewBanner'
 import { getPostByPreviewToken } from '@web/lib/db/queries/posts'
@@ -46,6 +47,14 @@ export default async function PreviewPage({ params }: RouteProps) {
         lng={lng}
       />
       <PostContent>{renderMDX(translation.content)}</PostContent>
+      <PostComments
+        postId={post.id}
+        postTitle={translation.title}
+        postNumber={post.postNumber ?? 0}
+        postSlug={translation.slug}
+        lng={lng}
+        commentsEnabled={post.commentsEnabled}
+      />
     </StyledPage>
   )
 }

--- a/apps/web/app/blog/preview/[token]/page.next.tsx
+++ b/apps/web/app/blog/preview/[token]/page.next.tsx
@@ -6,6 +6,7 @@ import { PostHero } from '@sdlgr/post-hero'
 import { PostComments } from '@web/components/PostComments'
 import { PostContent } from '@web/components/PostContent/PostContent'
 import { PreviewBanner } from '@web/components/PreviewBanner'
+import { auth } from '@web/lib/auth/config'
 import { getPostByPreviewToken } from '@web/lib/db/queries/posts'
 import { renderMDX } from '@web/lib/mdx/renderMDX'
 import { computeReadingTime } from '@web/utils/computeReadingTime'
@@ -17,6 +18,9 @@ interface RouteProps {
 }
 
 export default async function PreviewPage({ params }: RouteProps) {
+  const session = await auth()
+  if (!session) return notFound()
+
   const { token } = await params
   const result = await getPostByPreviewToken(token)
   if (!result) return notFound()

--- a/apps/web/app/blog/preview/[token]/page.next.tsx
+++ b/apps/web/app/blog/preview/[token]/page.next.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 
 import { PostHero } from '@sdlgr/post-hero'
 
+import StyledComponentsRegistry from '@web/components/StyledComponentsRegistry/StyledComponentsRegistry'
 import { getPostByPreviewToken } from '@web/lib/db/queries/posts'
 import { renderMDX } from '@web/lib/mdx/renderMDX'
 import { computeReadingTime } from '@web/utils/computeReadingTime'
@@ -30,18 +31,20 @@ export default async function PreviewPage({ params }: RouteProps) {
   if (!translation) return notFound()
 
   return (
-    <main>
-      <div data-testid="preview-banner">PREVIEW MODE</div>
-      <PostHero
-        title={translation.title}
-        coverImagePublicId={post.coverImage}
-        category={post.category}
-        author={authorName}
-        publishedAt={null}
-        readingTime={computeReadingTime(translation.content)}
-        lng={lng}
-      />
-      <article>{renderMDX(translation.content)}</article>
-    </main>
+    <StyledComponentsRegistry>
+      <main>
+        <div data-testid="preview-banner">PREVIEW MODE</div>
+        <PostHero
+          title={translation.title}
+          coverImagePublicId={post.coverImage}
+          category={post.category}
+          author={authorName}
+          publishedAt={null}
+          readingTime={computeReadingTime(translation.content)}
+          lng={lng}
+        />
+        <article>{renderMDX(translation.content)}</article>
+      </main>
+    </StyledComponentsRegistry>
   )
 }

--- a/apps/web/app/blog/preview/[token]/page.spec.tsx
+++ b/apps/web/app/blog/preview/[token]/page.spec.tsx
@@ -36,12 +36,23 @@ jest.mock('@web/lib/mdx/renderMDX', () => ({
   renderMDX: jest.fn().mockReturnValue(null),
 }))
 
-jest.mock(
-  '@web/components/StyledComponentsRegistry/StyledComponentsRegistry',
-  () =>
-    ({ children }: { children: React.ReactNode }) =>
-      children,
-)
+jest.mock('@web/components/PreviewBanner', () => ({
+  PreviewBanner: ({ label }: { label: string }) => (
+    <div data-testid="preview-banner">{label}</div>
+  ),
+}))
+
+jest.mock('@web/components/PostContent/PostContent', () => ({
+  PostContent: ({ children }: { children: React.ReactNode }) => (
+    <article data-testid="post-content">{children}</article>
+  ),
+}))
+
+jest.mock('./page.next.styles', () => ({
+  StyledPage: ({ children }: { children: React.ReactNode }) => (
+    <main data-testid="styled-page">{children}</main>
+  ),
+}))
 
 const mockPost = {
   id: '01ABC',
@@ -125,7 +136,7 @@ describe('blog/preview/[token] - PreviewPage', () => {
     })
     render(ui)
     expect(screen.getByTestId('preview-banner')).toHaveTextContent(
-      'PREVIEW MODE',
+      'Admin preview — this post is not publicly visible',
     )
   })
 

--- a/apps/web/app/blog/preview/[token]/page.spec.tsx
+++ b/apps/web/app/blog/preview/[token]/page.spec.tsx
@@ -21,6 +21,11 @@ jest.mock('@web/lib/db/queries/posts', () => ({
   getPostByPreviewToken: mockGetPostByPreviewToken,
 }))
 
+const mockAuth = jest.fn()
+jest.mock('@web/lib/auth/config', () => ({
+  auth: () => mockAuth(),
+}))
+
 jest.mock('@sdlgr/post-hero', () => {
   const React = require('react')
   return {
@@ -93,6 +98,15 @@ describe('blog/preview/[token] - PreviewPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPostComments.mockReturnValue(<div data-testid="post-comments" />)
+    mockAuth.mockResolvedValue({ user: { role: 'admin' } })
+  })
+
+  it('calls notFound when unauthenticated', async () => {
+    mockAuth.mockResolvedValue(null)
+    const { default: PreviewPage } = require('./page.next')
+    await PreviewPage({ params: Promise.resolve({ token: 'valid-token' }) })
+    expect(mockNotFound).toHaveBeenCalledTimes(1)
+    expect(mockGetPostByPreviewToken).not.toHaveBeenCalled()
   })
 
   it('calls notFound when token is invalid (null result)', async () => {

--- a/apps/web/app/blog/preview/[token]/page.spec.tsx
+++ b/apps/web/app/blog/preview/[token]/page.spec.tsx
@@ -36,6 +36,11 @@ jest.mock('@web/lib/mdx/renderMDX', () => ({
   renderMDX: jest.fn().mockReturnValue(null),
 }))
 
+const mockPostComments = jest.fn()
+jest.mock('@web/components/PostComments', () => ({
+  PostComments: (...args: unknown[]) => mockPostComments(...args),
+}))
+
 jest.mock('@web/components/PreviewBanner', () => ({
   PreviewBanner: ({ label }: { label: string }) => (
     <div data-testid="preview-banner">{label}</div>
@@ -56,20 +61,24 @@ jest.mock('./page.next.styles', () => ({
 
 const mockPost = {
   id: '01ABC',
+  postNumber: 7,
   coverImage: 'blog/cover',
   category: 'Tech',
   authorId: 'user-1',
+  commentsEnabled: true,
 }
 
 const mockTranslations = [
   {
     locale: 'en',
     title: 'English Title',
+    slug: 'english-title',
     content: 'English content',
   },
   {
     locale: 'es',
     title: 'Spanish Title',
+    slug: 'spanish-title',
     content: 'Spanish content',
   },
 ]
@@ -83,6 +92,7 @@ function makeHeadersList(acceptLanguage: string) {
 describe('blog/preview/[token] - PreviewPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPostComments.mockReturnValue(<div data-testid="post-comments" />)
   })
 
   it('calls notFound when token is invalid (null result)', async () => {
@@ -193,6 +203,31 @@ describe('blog/preview/[token] - PreviewPage', () => {
     render(ui)
     expect(PostHero).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'French Title' }),
+      undefined,
+    )
+  })
+
+  it('renders PostComments with correct props', async () => {
+    mockGetPostByPreviewToken.mockResolvedValue({
+      post: mockPost,
+      translations: mockTranslations,
+      authorName: 'Jane Doe',
+    })
+    mockHeaders.mockResolvedValue(makeHeadersList('en'))
+    const { default: PreviewPage } = require('./page.next')
+    const ui = await PreviewPage({
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+    render(ui)
+    expect(screen.getByTestId('post-comments')).toBeInTheDocument()
+    expect(mockPostComments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postId: '01ABC',
+        postNumber: 7,
+        postSlug: 'english-title',
+        lng: 'en',
+        commentsEnabled: true,
+      }),
       undefined,
     )
   })

--- a/apps/web/app/blog/preview/[token]/page.spec.tsx
+++ b/apps/web/app/blog/preview/[token]/page.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import React from 'react'
 
 import { PostHero } from '@sdlgr/post-hero'
 
@@ -34,6 +35,13 @@ jest.mock('@sdlgr/post-hero', () => {
 jest.mock('@web/lib/mdx/renderMDX', () => ({
   renderMDX: jest.fn().mockReturnValue(null),
 }))
+
+jest.mock(
+  '@web/components/StyledComponentsRegistry/StyledComponentsRegistry',
+  () =>
+    ({ children }: { children: React.ReactNode }) =>
+      children,
+)
 
 const mockPost = {
   id: '01ABC',

--- a/apps/web/app/blog/preview/[token]/page.spec.tsx
+++ b/apps/web/app/blog/preview/[token]/page.spec.tsx
@@ -245,4 +245,22 @@ describe('blog/preview/[token] - PreviewPage', () => {
       undefined,
     )
   })
+
+  it('falls back to 0 when postNumber is null', async () => {
+    mockGetPostByPreviewToken.mockResolvedValue({
+      post: { ...mockPost, postNumber: null },
+      translations: mockTranslations,
+      authorName: 'Jane Doe',
+    })
+    mockHeaders.mockResolvedValue(makeHeadersList('en'))
+    const { default: PreviewPage } = require('./page.next')
+    const ui = await PreviewPage({
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+    render(ui)
+    expect(mockPostComments).toHaveBeenCalledWith(
+      expect.objectContaining({ postNumber: 0 }),
+      undefined,
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- Draft posts on the public ISR route (`/[lng]/blog/[id]/[slug]`) now unconditionally return 404 — no auth check, no dynamic APIs
- Admin draft preview link now points to `/blog/preview/[token]` (always-dynamic, token-gated) instead of the public post URL
- Add `previewToken` to `PostEditorPost` interface and pass it through from the edit page

## Root cause

`auth()` and `connection()` both call dynamic APIs (`headers()`/`cookies()`). Calling either inside an ISR page triggers Next.js's "Page changed from static to dynamic at runtime" error. There is no way to conditionally switch a page from static to dynamic at request time — the mode must be fixed at build time.

## Test plan

- [ ] Open a published blog post — still served from ISR cache, no change
- [ ] Open an unpublished post URL directly — returns 404
- [ ] Open admin post editor for a draft → "Preview" link points to `/blog/preview/[token]`
- [ ] `/blog/preview/[token]` renders the draft post correctly
- [ ] All 2126 tests pass, 100% coverage