### PR TITLE
feat: add slideshow block to post editor and content viewer

### DIFF
--- a/apps/web/app/admin/(auth)/posts/components/ImageInsertModal/ImageInsertModal.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/ImageInsertModal/ImageInsertModal.spec.tsx
@@ -6,6 +6,33 @@ import type { CloudinaryImage } from '@web/lib/cloudinary/images'
 
 import { ImageInsertModal, buildImageMarkdown } from './ImageInsertModal'
 
+jest.mock('@sdlgr/select', () => ({
+  Select: ({
+    value,
+    onChange,
+    'data-testid': testId,
+    isSearchable,
+    isClearable: _isClearable,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    'data-testid'?: string
+    isSearchable?: boolean
+    isClearable?: boolean
+  }) => {
+    if (isSearchable) {
+      return (
+        <input
+          data-testid={testId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )
+    }
+    return null
+  },
+}))
+
 const mockPickedImage: CloudinaryImage = {
   url: 'https://cdn.com/photo.jpg',
   publicId: 'photo',
@@ -684,7 +711,7 @@ describe('ImageInsertModal', () => {
     pickImage(onRequestImagePick)
     fireEvent.click(screen.getByTestId('photo-meta-checkbox'))
     fireEvent.change(screen.getByTestId('photo-focal-length-input'), {
-      target: { value: '50mm' },
+      target: { value: '50' },
     })
     fireEvent.click(screen.getByTestId('image-modal-insert'))
     expect(onInsert).toHaveBeenCalledWith(
@@ -735,7 +762,7 @@ describe('ImageInsertModal', () => {
       target: { value: '400' },
     })
     fireEvent.change(screen.getByTestId('photo-focal-length-input'), {
-      target: { value: '50mm' },
+      target: { value: '50' },
     })
     fireEvent.change(screen.getByTestId('photo-panoramic-count-input'), {
       target: { value: '12' },
@@ -840,7 +867,7 @@ describe('ImageInsertModal initialValues', () => {
     expect(screen.getByTestId('photo-iso-input')).toHaveValue('400')
     expect(screen.getByTestId('photo-aperture-input')).toHaveValue('f/2.8')
     expect(screen.getByTestId('photo-exposure-input')).toHaveValue('1/250')
-    expect(screen.getByTestId('photo-focal-length-input')).toHaveValue('50mm')
+    expect(screen.getByTestId('photo-focal-length-input')).toHaveValue(50)
     expect(screen.getByTestId('photo-panoramic-count-input')).toHaveValue('12')
   })
 
@@ -865,7 +892,7 @@ describe('ImageInsertModal initialValues', () => {
       />,
     )
     expect(screen.getByTestId('photo-meta-checkbox')).toBeChecked()
-    expect(screen.getByTestId('photo-focal-length-input')).toHaveValue('35mm')
+    expect(screen.getByTestId('photo-focal-length-input')).toHaveValue(35)
   })
 
   it('enables photo meta when only panoramicCount provided', () => {

--- a/apps/web/app/admin/(auth)/posts/components/ImageInsertModal/ImageInsertModal.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/ImageInsertModal/ImageInsertModal.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { RenderModalBackdropProps } from 'react-overlays/Modal'
 
+import { Select } from '@sdlgr/select'
+
 import type { CloudinaryImage } from '@web/lib/cloudinary/images'
 
 import type { ParsedImage } from '../PostEditor/parseEmbedBlock'
@@ -26,6 +28,57 @@ import {
   StyledSegmentButton,
   StyledSegmentRow,
 } from './ImageInsertModal.styles'
+
+const ISO_OPTIONS = [
+  '100',
+  '200',
+  '400',
+  '800',
+  '1600',
+  '3200',
+  '6400',
+  '12800',
+  '25600',
+  '51200',
+].map((v) => ({ value: v, label: v }))
+
+const APERTURE_OPTIONS = [
+  'f/1.4',
+  'f/1.8',
+  'f/2',
+  'f/2.8',
+  'f/4',
+  'f/5.6',
+  'f/8',
+  'f/9',
+  'f/10',
+  'f/11',
+  'f/16',
+  'f/22',
+].map((v) => ({ value: v, label: v }))
+
+const SHUTTER_SPEED_OPTIONS = [
+  '1/8000',
+  '1/4000',
+  '1/2000',
+  '1/1000',
+  '1/500',
+  '1/400',
+  '1/320',
+  '1/250',
+  '1/125',
+  '1/60',
+  '1/30',
+  '1/15',
+  '1/8',
+  '1/4',
+  '1/2',
+  '1s',
+  '2s',
+  '5s',
+  '10s',
+  '30s',
+].map((v) => ({ value: v, label: v }))
 
 export interface ImageInsertModalProps {
   isOpen: boolean
@@ -116,7 +169,7 @@ export function ImageInsertModal({
     initialValues?.photoMeta?.aperture ?? '',
   )
   const [photoFocalLength, setPhotoFocalLength] = useState(
-    initialValues?.photoMeta?.focalLength ?? '',
+    initialValues?.photoMeta?.focalLength?.replace(/mm$/, '') ?? '',
   )
   const [photoPanoramicCount, setPhotoPanoramicCount] = useState(
     initialValues?.photoMeta?.panoramicCount ?? '',
@@ -138,7 +191,7 @@ export function ImageInsertModal({
             iso: photoIso,
             exposure: photoExposure,
             aperture: photoAperture,
-            focalLength: photoFocalLength,
+            focalLength: photoFocalLength ? `${photoFocalLength}mm` : '',
             panoramicCount: photoPanoramicCount,
           }
         : undefined,
@@ -173,7 +226,7 @@ export function ImageInsertModal({
               iso: photoIso,
               exposure: photoExposure,
               aperture: photoAperture,
-              focalLength: photoFocalLength,
+              focalLength: photoFocalLength ? `${photoFocalLength}mm` : '',
               panoramicCount: photoPanoramicCount,
             }
           : undefined,
@@ -303,30 +356,39 @@ export function ImageInsertModal({
           <StyledPhotoMetaInputRow>
             <StyledPhotoMetaField>
               <StyledLabel htmlFor="photo-iso">ISO</StyledLabel>
-              <StyledInput
+              <Select
                 id="photo-iso"
                 value={photoIso}
-                onChange={(e) => setPhotoIso(e.target.value)}
+                onChange={setPhotoIso}
+                options={ISO_OPTIONS}
+                isSearchable
+                isClearable
                 placeholder="e.g. 400"
                 data-testid="photo-iso-input"
               />
             </StyledPhotoMetaField>
             <StyledPhotoMetaField>
               <StyledLabel htmlFor="photo-aperture">Aperture</StyledLabel>
-              <StyledInput
+              <Select
                 id="photo-aperture"
                 value={photoAperture}
-                onChange={(e) => setPhotoAperture(e.target.value)}
+                onChange={setPhotoAperture}
+                options={APERTURE_OPTIONS}
+                isSearchable
+                isClearable
                 placeholder="e.g. f/2.8"
                 data-testid="photo-aperture-input"
               />
             </StyledPhotoMetaField>
             <StyledPhotoMetaField>
-              <StyledLabel htmlFor="photo-exposure">Exposure</StyledLabel>
-              <StyledInput
+              <StyledLabel htmlFor="photo-exposure">Shutter speed</StyledLabel>
+              <Select
                 id="photo-exposure"
                 value={photoExposure}
-                onChange={(e) => setPhotoExposure(e.target.value)}
+                onChange={setPhotoExposure}
+                options={SHUTTER_SPEED_OPTIONS}
+                isSearchable
+                isClearable
                 placeholder="e.g. 1/250"
                 data-testid="photo-exposure-input"
               />
@@ -337,9 +399,11 @@ export function ImageInsertModal({
               </StyledLabel>
               <StyledInput
                 id="photo-focal-length"
+                type="number"
+                min="1"
                 value={photoFocalLength}
                 onChange={(e) => setPhotoFocalLength(e.target.value)}
-                placeholder="e.g. 50mm"
+                placeholder="e.g. 50"
                 data-testid="photo-focal-length-input"
               />
             </StyledPhotoMetaField>

--- a/apps/web/app/admin/(auth)/posts/components/ImagePicker/ImagePicker.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/ImagePicker/ImagePicker.spec.tsx
@@ -669,6 +669,23 @@ describe('ImagePicker', () => {
     )
   })
 
+  it('deduplicates images with the same publicId in the display list', async () => {
+    jest.spyOn(axios, 'get').mockResolvedValue({
+      data: {
+        images: [mockImages[0], mockImages[1], mockImages[0]],
+        nextCursor: undefined,
+      },
+    })
+
+    renderApp(
+      <ImagePicker open={true} onClose={mockOnClose} onPick={mockOnPick} />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('image-picker-item')).toHaveLength(2),
+    )
+  })
+
   it('disconnects IntersectionObserver on unmount', async () => {
     const { unmount } = renderApp(
       <ImagePicker open={true} onClose={mockOnClose} onPick={mockOnPick} />,

--- a/apps/web/app/admin/(auth)/posts/components/ImagePicker/ImagePicker.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/ImagePicker/ImagePicker.tsx
@@ -244,9 +244,17 @@ export function ImagePicker({
     }, 300)
   }
 
-  const displayImages = [...images].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  )
+  const seen = new Set<string>()
+  const displayImages = images
+    .filter((img) => {
+      if (seen.has(img.publicId)) return false
+      seen.add(img.publicId)
+      return true
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    )
 
   return (
     <StyledSidebar

--- a/apps/web/app/admin/(auth)/posts/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/MarkdownPreview/MarkdownPreview.tsx
@@ -10,6 +10,7 @@ import { CodeBlock } from '@sdlgr/code-block'
 import { MdxTable } from '@web/components/PostContent/MdxTable'
 import { PostContentEmbed } from '@web/components/PostContent/PostContentEmbed'
 import { PostContentImage } from '@web/components/PostContent/PostContentImage'
+import { PostContentSlideshow } from '@web/components/PostContent/PostContentSlideshow'
 
 import { serializePreview } from '../../actions/serializePreview'
 import { StyledLoading, StyledPreviewWrapper } from './MarkdownPreview.styles'
@@ -44,6 +45,7 @@ const MDX_COMPONENTS = {
   pre: PreCodeBlock,
   img: PostContentImage,
   Embed: PostContentEmbed,
+  Slideshow: PostContentSlideshow,
   h1: H1AsH2,
   table: TableComponent,
 }

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.embed.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.embed.spec.tsx
@@ -159,6 +159,50 @@ jest.mock('../GpxMapModal', () => ({
     ) : null,
 }))
 
+jest.mock('../SlideshowInsertModal', () => ({
+  SlideshowInsertModal: ({
+    isOpen,
+    onInsert,
+    onCancel,
+    onRequestImagePick,
+  }: {
+    isOpen: boolean
+    onInsert: (markdown: string) => void
+    onCancel: () => void
+    onRequestImagePick: (onPicked: (image: { url: string }) => void) => void
+    [key: string]: unknown
+  }) =>
+    isOpen ? (
+      <div data-testid="slideshow-insert-modal-mock">
+        <button
+          type="button"
+          data-testid="slideshow-modal-insert-mock"
+          onClick={() =>
+            onInsert(
+              '\n\n```slideshow\n![](https://example.com/new.jpg)\n```\n\n',
+            )
+          }
+        >
+          Insert
+        </button>
+        <button
+          type="button"
+          data-testid="slideshow-modal-cancel-mock"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          data-testid="slideshow-modal-request-pick"
+          onClick={() => onRequestImagePick(jest.fn())}
+        >
+          Request Pick
+        </button>
+      </div>
+    ) : null,
+}))
+
 jest.mock('../ImagePicker', () => ({
   ImagePicker: () => null,
 }))
@@ -434,5 +478,84 @@ describe('PostEditor embed edit-in-place', () => {
     fireEvent.click(screen.getByTestId('edit-embed-button'))
     fireEvent.click(screen.getByTestId('gpx-modal-cancel-mock'))
     expect(screen.queryByTestId('gpx-map-modal-mock')).not.toBeInTheDocument()
+  })
+
+  it('shows edit button when cursor is inside a slideshow block', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content =
+      'Intro\n\n```slideshow\n![](https://example.com/img.jpg)\n```\n\nOutro'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```slideshow') + 5
+    textarea.selectionEnd = content.indexOf('```slideshow') + 5
+    fireEvent.click(textarea)
+    expect(screen.getByTestId('edit-embed-button')).toBeInTheDocument()
+    expect(screen.getByTestId('edit-embed-button')).toHaveTextContent(
+      'Edit slideshow',
+    )
+  })
+
+  it('opens slideshow modal when edit button clicked on slideshow block', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content =
+      'Intro\n\n```slideshow\n![](https://example.com/img.jpg)\n```\n\nOutro'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```slideshow') + 5
+    textarea.selectionEnd = content.indexOf('```slideshow') + 5
+    fireEvent.click(textarea)
+    fireEvent.click(screen.getByTestId('edit-embed-button'))
+    expect(
+      screen.getByTestId('slideshow-insert-modal-mock'),
+    ).toBeInTheDocument()
+  })
+
+  it('replaces slideshow block on modal insert', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content =
+      'Before\n\n```slideshow\n![](https://example.com/old.jpg)\n```\n\nAfter'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```slideshow') + 5
+    textarea.selectionEnd = content.indexOf('```slideshow') + 5
+    fireEvent.click(textarea)
+    fireEvent.click(screen.getByTestId('edit-embed-button'))
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert-mock'))
+    const newContent = (
+      screen.getByTestId('content-input') as HTMLTextAreaElement
+    ).value
+    expect(newContent).not.toContain('https://example.com/old.jpg')
+    expect(newContent).toContain('Before')
+    expect(newContent).toContain('After')
+    expect(newContent).toContain('https://example.com/new.jpg')
+  })
+
+  it('cancel on slideshow modal during edit clears initialValues', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content =
+      'Intro\n\n```slideshow\n![](https://example.com/img.jpg)\n```\n\nOutro'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```slideshow') + 5
+    textarea.selectionEnd = content.indexOf('```slideshow') + 5
+    fireEvent.click(textarea)
+    fireEvent.click(screen.getByTestId('edit-embed-button'))
+    fireEvent.click(screen.getByTestId('slideshow-modal-cancel-mock'))
+    expect(
+      screen.queryByTestId('slideshow-insert-modal-mock'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('onRequestImagePick for slideshow modal sets content picker callback', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    fireEvent.click(screen.getByTestId('open-slideshow-modal-button'))
+    expect(
+      screen.getByTestId('slideshow-insert-modal-mock'),
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('slideshow-modal-request-pick'))
+    // After requesting a pick, content picker should be open (pickerOpen=true)
+    expect(
+      screen.getByTestId('slideshow-insert-modal-mock'),
+    ).toBeInTheDocument()
   })
 })

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.spec.tsx
@@ -134,6 +134,41 @@ jest.mock('../EmbedInsertModal', () => ({
     ) : null,
 }))
 
+jest.mock('../SlideshowInsertModal', () => ({
+  SlideshowInsertModal: ({
+    isOpen,
+    onInsert,
+    onCancel,
+  }: {
+    isOpen: boolean
+    onInsert: (markdown: string) => void
+    onCancel: () => void
+    [key: string]: unknown
+  }) =>
+    isOpen ? (
+      <div data-testid="slideshow-insert-modal-mock">
+        <button
+          type="button"
+          data-testid="slideshow-modal-insert-mock"
+          onClick={() =>
+            onInsert(
+              '\n\n```slideshow\n![](https://example.com/1.jpg)\n```\n\n',
+            )
+          }
+        >
+          Insert
+        </button>
+        <button
+          type="button"
+          data-testid="slideshow-modal-cancel-mock"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}))
+
 jest.mock('../GpxMapModal', () => ({
   GpxMapModal: ({
     isOpen,
@@ -1477,6 +1512,47 @@ describe('PostEditor', () => {
         'Hello \n\n```gpx\nhttps://example.com/track.gpx\n```\n\n',
       )
       expect(screen.queryByTestId('gpx-map-modal-mock')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Slideshow insert modal', () => {
+    it('does not show slideshow modal by default', () => {
+      renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+      expect(
+        screen.queryByTestId('slideshow-insert-modal-mock'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows slideshow modal when insert slideshow button clicked', () => {
+      renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+      fireEvent.click(screen.getByTestId('open-slideshow-modal-button'))
+      expect(
+        screen.getByTestId('slideshow-insert-modal-mock'),
+      ).toBeInTheDocument()
+    })
+
+    it('closes slideshow modal when cancel is clicked', () => {
+      renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+      fireEvent.click(screen.getByTestId('open-slideshow-modal-button'))
+      fireEvent.click(screen.getByTestId('slideshow-modal-cancel-mock'))
+      expect(
+        screen.queryByTestId('slideshow-insert-modal-mock'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('inserts markdown at cursor and closes modal on insert', () => {
+      renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+      fireEvent.change(screen.getByTestId('content-input'), {
+        target: { value: 'Hello ' },
+      })
+      fireEvent.click(screen.getByTestId('open-slideshow-modal-button'))
+      fireEvent.click(screen.getByTestId('slideshow-modal-insert-mock'))
+      expect(screen.getByTestId('content-input')).toHaveValue(
+        'Hello \n\n```slideshow\n![](https://example.com/1.jpg)\n```\n\n',
+      )
+      expect(
+        screen.queryByTestId('slideshow-insert-modal-mock'),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.styles.ts
@@ -194,6 +194,24 @@ export const StyledPreviewControls = styled.div`
   padding: 0 0.5rem;
 `
 
+export const StyledCheckboxFieldLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.5;
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    accent-color: ${({ theme }) => theme.colors.green};
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+`
+
 export const StyledAutoRenderLabel = styled.label`
   display: flex;
   align-items: center;
@@ -395,13 +413,13 @@ export const StyledEditEmbedButton = styled(Button).attrs({
   text-transform: uppercase;
   letter-spacing: 0.1em;
   padding: 0.25rem 0.6rem;
-  background: rgba(58, 134, 255, 0.15);
-  border-color: rgba(58, 134, 255, 0.4);
+  background: rgba(58, 134, 255, 0.3);
+  border-color: rgba(58, 134, 255, 0.6);
   color: ${({ theme }) => theme.colors.white};
 
   &:hover {
-    background: rgba(58, 134, 255, 0.3);
-    border-color: rgba(58, 134, 255, 0.7);
+    background: rgba(58, 134, 255, 0.45);
+    border-color: rgba(58, 134, 255, 0.85);
   }
 `
 

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
@@ -35,6 +35,7 @@ import { GpxMapModal } from '../GpxMapModal'
 import { ImageInsertModal } from '../ImageInsertModal'
 import { ImagePicker } from '../ImagePicker'
 import { MarkdownPreview } from '../MarkdownPreview'
+import { SlideshowInsertModal } from '../SlideshowInsertModal'
 import { CoverImageInput } from './CoverImageInput'
 import { PostCardPreview } from './PostCardPreview'
 import {
@@ -42,6 +43,7 @@ import {
   StyledArchiveButton,
   StyledAutoRenderLabel,
   StyledBackLink,
+  StyledCheckboxFieldLabel,
   StyledContentTextarea,
   StyledDraftPreviewCopyButton,
   StyledDraftPreviewLabel,
@@ -82,6 +84,7 @@ import type {
   ParsedEmbed,
   ParsedGpx,
   ParsedImage,
+  ParsedSlideshow,
 } from './parseEmbedBlock'
 import { detectEmbedAtCursor } from './parseEmbedBlock'
 
@@ -274,6 +277,10 @@ export function PostEditor({
   const [gpxInitialValues, setGpxInitialValues] = useState<ParsedGpx | null>(
     null,
   )
+  const [isSlideshowModalOpen, setIsSlideshowModalOpen] = useState(false)
+  const [slideshowModalKey, setSlideshowModalKey] = useState(0)
+  const [slideshowInitialValues, setSlideshowInitialValues] =
+    useState<ParsedSlideshow | null>(null)
   const [previewTab, setPreviewTab] = useState<
     'post' | 'post-mobile' | 'hero' | 'card' | 'toc'
   >('post')
@@ -351,6 +358,10 @@ export function PostEditor({
       setEmbedInitialValues(editingEmbed.parsed as ParsedEmbed)
       setEmbedModalKey((k) => k + 1)
       setIsEmbedInsertModalOpen(true)
+    } else if (editingEmbed.type === 'slideshow') {
+      setSlideshowInitialValues(editingEmbed.parsed as ParsedSlideshow)
+      setSlideshowModalKey((k) => k + 1)
+      setIsSlideshowModalOpen(true)
     } else {
       setGpxInitialValues(editingEmbed.parsed as ParsedGpx)
       setGpxModalKey((k) => k + 1)
@@ -793,19 +804,6 @@ export function PostEditor({
               </FieldGroup>
 
               <FieldGroup>
-                <FieldLabel htmlFor="meta-comments-enabled">
-                  {t('postEditor.fields.commentsEnabled')}
-                </FieldLabel>
-                <input
-                  id="meta-comments-enabled"
-                  type="checkbox"
-                  checked={commentsEnabled}
-                  onChange={(e) => setCommentsEnabled(e.target.checked)}
-                  data-testid="comments-enabled-checkbox"
-                />
-              </FieldGroup>
-
-              <FieldGroup>
                 <FieldLabel htmlFor="meta-cover-image-fit">
                   {t('postEditor.fields.coverImageFit')}
                 </FieldLabel>
@@ -852,6 +850,17 @@ export function PostEditor({
                   />
                 )}
               </FieldGroup>
+
+              <StyledCheckboxFieldLabel>
+                <input
+                  id="meta-comments-enabled"
+                  type="checkbox"
+                  checked={commentsEnabled}
+                  onChange={(e) => setCommentsEnabled(e.target.checked)}
+                  data-testid="comments-enabled-checkbox"
+                />
+                {t('postEditor.fields.commentsEnabled')}
+              </StyledCheckboxFieldLabel>
             </StyledMetaGrid>
           </StyledMetadataSection>
 
@@ -895,6 +904,18 @@ export function PostEditor({
                 data-testid="open-gpx-modal-button"
               >
                 Insert GPX Map
+              </StyledImagePickerButton>
+              <StyledImagePickerButton
+                type="button"
+                onClick={() => {
+                  setEditingEmbed(null)
+                  setSlideshowInitialValues(null)
+                  setSlideshowModalKey((k) => k + 1)
+                  setIsSlideshowModalOpen(true)
+                }}
+                data-testid="open-slideshow-modal-button"
+              >
+                Insert Slideshow
               </StyledImagePickerButton>
             </StyledToolbarRow>
             <StyledTextareaWrapper>
@@ -1145,6 +1166,33 @@ export function PostEditor({
         onCancel={() => {
           setIsGpxModalOpen(false)
           setGpxInitialValues(null)
+        }}
+      />
+      <SlideshowInsertModal
+        key={`slideshow-${slideshowModalKey}`}
+        isOpen={isSlideshowModalOpen}
+        initialValues={slideshowInitialValues}
+        onInsert={(markdown) => {
+          if (editingEmbed?.type === 'slideshow') {
+            replaceBlock(
+              editingEmbed.blockStart,
+              editingEmbed.blockEnd,
+              markdown,
+            )
+          } else {
+            insertAtCursor(markdown)
+          }
+          setIsSlideshowModalOpen(false)
+          setSlideshowInitialValues(null)
+        }}
+        onCancel={() => {
+          setIsSlideshowModalOpen(false)
+          setSlideshowInitialValues(null)
+        }}
+        pickerOpen={isContentPickerOpen}
+        onRequestImagePick={(onPicked) => {
+          contentPickerCallbackRef.current = onPicked
+          setIsContentPickerOpen(true)
         }}
       />
       <PublishNotifyModal

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.spec.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.spec.ts
@@ -424,6 +424,67 @@ describe('detectEmbedAtCursor', () => {
     })
   })
 
+  describe('slideshow blocks', () => {
+    const slideshowContent =
+      '\n\n```slideshow\n![caption=Sunset&alt=A sunset photo&photo-iso=400&photo-aperture=f/2.8&photo-exposure=1/250&photo-focal-length=50mm&photo-panoramic-count=3](https://example.com/img1.jpg)\n![](https://example.com/img2.jpg)\n```\n\n'
+
+    it('detects a slideshow block when cursor is inside', () => {
+      const fenceStart = slideshowContent.indexOf('```slideshow')
+      const result = detectEmbedAtCursor(slideshowContent, fenceStart + 5)
+      expect(result).not.toBeNull()
+      expect(result?.type).toBe('slideshow')
+    })
+
+    it('parses slide URL from the block', () => {
+      const fenceStart = slideshowContent.indexOf('```slideshow')
+      const result = detectEmbedAtCursor(slideshowContent, fenceStart + 5)
+      if (result?.type !== 'slideshow') throw new Error('expected slideshow')
+      expect(result.parsed.slides).toHaveLength(2)
+      expect(result.parsed.slides[0].url).toBe('https://example.com/img1.jpg')
+      expect(result.parsed.slides[1].url).toBe('https://example.com/img2.jpg')
+    })
+
+    it('parses slide with photo metadata', () => {
+      const fenceStart = slideshowContent.indexOf('```slideshow')
+      const result = detectEmbedAtCursor(slideshowContent, fenceStart + 5)
+      if (result?.type !== 'slideshow') throw new Error('expected slideshow')
+      const slide = result.parsed.slides[0]
+      expect(slide.photoMeta?.iso).toBe('400')
+      expect(slide.photoMeta?.aperture).toBe('f/2.8')
+      expect(slide.photoMeta?.exposure).toBe('1/250')
+      expect(slide.photoMeta?.focalLength).toBe('50mm')
+      expect(slide.photoMeta?.panoramicCount).toBe('3')
+    })
+
+    it('parses slide with caption and alt text', () => {
+      const fenceStart = slideshowContent.indexOf('```slideshow')
+      const result = detectEmbedAtCursor(slideshowContent, fenceStart + 5)
+      if (result?.type !== 'slideshow') throw new Error('expected slideshow')
+      const slide = result.parsed.slides[0]
+      expect(slide.caption).toBe('Sunset')
+      expect(slide.altText).toBe('A sunset photo')
+    })
+
+    it('detects slideshow (not image) when cursor is on an image line inside the fence', () => {
+      const imageLineStart = slideshowContent.indexOf('![caption=')
+      const result = detectEmbedAtCursor(slideshowContent, imageLineStart + 5)
+      expect(result?.type).toBe('slideshow')
+    })
+
+    it('returns null when cursor is outside the slideshow block', () => {
+      const result = detectEmbedAtCursor(slideshowContent, 1)
+      expect(result).toBeNull()
+    })
+
+    it('handles empty slideshow body with no image lines', () => {
+      const emptySlideshow = '\n\n```slideshow\n```\n\n'
+      const fenceStart = emptySlideshow.indexOf('```slideshow')
+      const result = detectEmbedAtCursor(emptySlideshow, fenceStart + 5)
+      if (result?.type !== 'slideshow') throw new Error('expected slideshow')
+      expect(result.parsed.slides).toEqual([])
+    })
+  })
+
   it('returns null for plain text content', () => {
     expect(detectEmbedAtCursor('Just some plain text here.', 5)).toBeNull()
   })

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.ts
@@ -41,10 +41,22 @@ export interface ParsedGpx {
   mappingsByTrack: Record<number, Array<{ name: string; imageUrl: string }>>
 }
 
+export type ParsedSlideshowSlide = ParsedImage
+
+export interface ParsedSlideshow {
+  slides: ParsedSlideshowSlide[]
+}
+
 export type DetectedEmbed =
   | { type: 'image'; blockStart: number; blockEnd: number; parsed: ParsedImage }
   | { type: 'embed'; blockStart: number; blockEnd: number; parsed: ParsedEmbed }
   | { type: 'gpx'; blockStart: number; blockEnd: number; parsed: ParsedGpx }
+  | {
+      type: 'slideshow'
+      blockStart: number
+      blockEnd: number
+      parsed: ParsedSlideshow
+    }
 
 const EMBED_TYPES: EmbedType[] = [
   'youtube',
@@ -193,24 +205,11 @@ export function detectEmbedAtCursor(
   content: string,
   pos: number,
 ): DetectedEmbed | null {
-  // Image blocks: ![params](url)
-  const imageRe = /!\[([^\]]*)\]\(([^)]+)\)/g
   let m: RegExpExecArray | null
-  while ((m = imageRe.exec(content)) !== null) {
-    const { index } = m
-    const blockEnd = index + m[0].length
-    if (pos >= index && pos <= blockEnd) {
-      const { start, end } = adjustBounds(content, index, blockEnd)
-      return {
-        type: 'image',
-        blockStart: start,
-        blockEnd: end,
-        parsed: { url: m[2], ...parseImageParams(m[1]) },
-      }
-    }
-  }
 
-  // Code fence blocks: ```type\n...\n```
+  // Code fence blocks first: ```type\n...\n```
+  // Must run before image check so that ![...](url) lines inside fences
+  // are not mistakenly detected as standalone images.
   const fenceRe = /```([a-z0-9-]+)\n([\s\S]*?)```/g
   while ((m = fenceRe.exec(content)) !== null) {
     const { index } = m
@@ -230,6 +229,21 @@ export function detectEmbedAtCursor(
         }
       }
 
+      if (fenceType === 'slideshow') {
+        const slideRe = /!\[([^\]]*)\]\(([^)]+)\)/g
+        const slides: ParsedSlideshowSlide[] = []
+        let sm: RegExpExecArray | null
+        while ((sm = slideRe.exec(body)) !== null) {
+          slides.push({ url: sm[2], ...parseImageParams(sm[1]) })
+        }
+        return {
+          type: 'slideshow',
+          blockStart: start,
+          blockEnd: end,
+          parsed: { slides },
+        }
+      }
+
       if ((EMBED_TYPES as string[]).includes(fenceType)) {
         return {
           type: 'embed',
@@ -237,6 +251,22 @@ export function detectEmbedAtCursor(
           blockEnd: end,
           parsed: { type: fenceType as EmbedType, url: body },
         }
+      }
+    }
+  }
+
+  // Standalone image blocks: ![params](url)
+  const imageRe = /!\[([^\]]*)\]\(([^)]+)\)/g
+  while ((m = imageRe.exec(content)) !== null) {
+    const { index } = m
+    const blockEnd = index + m[0].length
+    if (pos >= index && pos <= blockEnd) {
+      const { start, end } = adjustBounds(content, index, blockEnd)
+      return {
+        type: 'image',
+        blockStart: start,
+        blockEnd: end,
+        parsed: { url: m[2], ...parseImageParams(m[1]) },
       }
     }
   }

--- a/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/SlideshowInsertModal.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/SlideshowInsertModal.spec.tsx
@@ -1,0 +1,882 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+import type { CloudinaryImage } from '@web/lib/cloudinary/images'
+
+import {
+  SlideshowInsertModal,
+  buildSlideMarkdown,
+  buildSlideshowMarkdown,
+} from './SlideshowInsertModal'
+import type { SlideState } from './SlideshowInsertModal'
+
+jest.mock('react-overlays', () => ({
+  Modal: ({
+    show,
+    children,
+    onHide,
+    renderBackdrop,
+    ...rest
+  }: {
+    show: boolean
+    children: React.ReactNode
+    onHide: () => void
+    renderBackdrop?: (props: Record<string, unknown>) => React.ReactNode
+    [key: string]: unknown
+  }) => {
+    if (!show) return null
+    return (
+      <div {...rest}>
+        {renderBackdrop?.({ onClick: onHide })}
+        {children}
+      </div>
+    )
+  },
+}))
+
+jest.mock('@sdlgr/select', () => ({
+  Select: ({
+    value,
+    onChange,
+    'data-testid': testId,
+    isSearchable: _isSearchable,
+    isClearable: _isClearable,
+    ...rest
+  }: {
+    value: string
+    onChange: (v: string) => void
+    'data-testid'?: string
+    isSearchable?: boolean
+    isClearable?: boolean
+    [key: string]: unknown
+  }) => (
+    <input
+      {...rest}
+      data-testid={testId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}))
+
+const mockPickedImage: CloudinaryImage = {
+  url: 'https://example.com/photo.jpg',
+} as CloudinaryImage
+
+function makeSlide(overrides: Partial<SlideState> = {}): SlideState {
+  return {
+    id: 'test-id',
+    selectedImage: null,
+    altText: '',
+    caption: '',
+    captionPos: 'bottom',
+    expand: false,
+    photoMetaEnabled: false,
+    photoIso: '',
+    photoExposure: '',
+    photoAperture: '',
+    photoFocalLength: '',
+    photoPanoramicCount: '',
+    ...overrides,
+  }
+}
+
+function pickImageForSlide(onRequestImagePick: jest.Mock, callIndex = 0) {
+  const [cb] = onRequestImagePick.mock.calls[callIndex] as [
+    (img: CloudinaryImage) => void,
+  ]
+  act(() => cb(mockPickedImage))
+}
+
+describe('buildSlideMarkdown', () => {
+  it('returns null when no selectedImage', () => {
+    const slide = makeSlide()
+    expect(buildSlideMarkdown(slide)).toBeNull()
+  })
+
+  it('returns ![](url) for slide with image and no params', () => {
+    const slide = makeSlide({ selectedImage: mockPickedImage })
+    expect(buildSlideMarkdown(slide)).toBe('![](https://example.com/photo.jpg)')
+  })
+
+  it('includes caption in params', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      caption: 'My caption',
+    })
+    expect(buildSlideMarkdown(slide)).toBe(
+      '![caption=My caption](https://example.com/photo.jpg)',
+    )
+  })
+
+  it('includes caption-pos=top when captionPos is top', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      caption: 'My caption',
+      captionPos: 'top',
+    })
+    expect(buildSlideMarkdown(slide)).toBe(
+      '![caption=My caption&caption-pos=top](https://example.com/photo.jpg)',
+    )
+  })
+
+  it('includes alt text in params', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      altText: 'A sunset photo',
+    })
+    expect(buildSlideMarkdown(slide)).toBe(
+      '![alt=A sunset photo](https://example.com/photo.jpg)',
+    )
+  })
+
+  it('includes expand=true when expand is true', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      expand: true,
+    })
+    expect(buildSlideMarkdown(slide)).toBe(
+      '![expand=true](https://example.com/photo.jpg)',
+    )
+  })
+
+  it('includes photo meta params when photoMetaEnabled is true', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      photoMetaEnabled: true,
+      photoIso: '400',
+      photoAperture: 'f/2.8',
+      photoExposure: '1/250',
+      photoFocalLength: '50',
+      photoPanoramicCount: '3',
+    })
+    expect(buildSlideMarkdown(slide)).toBe(
+      '![photo-iso=400&photo-aperture=f/2.8&photo-exposure=1/250&photo-focal-length=50mm&photo-panoramic-count=3](https://example.com/photo.jpg)',
+    )
+  })
+
+  it('omits photo meta when photoMetaEnabled is false', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      photoMetaEnabled: false,
+      photoIso: '400',
+      photoAperture: 'f/2.8',
+    })
+    const result = buildSlideMarkdown(slide)
+    expect(result).not.toContain('photo-')
+  })
+
+  it('focal length gets mm suffix appended', () => {
+    const slide = makeSlide({
+      selectedImage: mockPickedImage,
+      photoMetaEnabled: true,
+      photoFocalLength: '35',
+    })
+    expect(buildSlideMarkdown(slide)).toContain('photo-focal-length=35mm')
+  })
+})
+
+describe('buildSlideshowMarkdown', () => {
+  it('returns empty string when all slides have no selectedImage', () => {
+    const slides = [makeSlide(), makeSlide()]
+    expect(buildSlideshowMarkdown(slides)).toBe('')
+  })
+
+  it('wraps valid slides in slideshow fence', () => {
+    const slides = [makeSlide({ selectedImage: mockPickedImage })]
+    expect(buildSlideshowMarkdown(slides)).toBe(
+      '\n\n```slideshow\n![](https://example.com/photo.jpg)\n```\n\n',
+    )
+  })
+
+  it('skips slides without images', () => {
+    const slides = [
+      makeSlide(),
+      makeSlide({ selectedImage: mockPickedImage }),
+      makeSlide(),
+    ]
+    expect(buildSlideshowMarkdown(slides)).toBe(
+      '\n\n```slideshow\n![](https://example.com/photo.jpg)\n```\n\n',
+    )
+  })
+})
+
+describe('SlideshowInsertModal', () => {
+  it('renders nothing when isOpen is false', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen={false}
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('slide-card-0')).not.toBeInTheDocument()
+  })
+
+  it('renders modal content when isOpen is true', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.getByTestId('slide-card-0')).toBeInTheDocument()
+    expect(screen.getByTestId('pick-image-button-0')).toBeInTheDocument()
+    expect(screen.getByTestId('add-slide-button')).toBeInTheDocument()
+    expect(screen.getByTestId('slideshow-modal-cancel')).toBeInTheDocument()
+    expect(screen.getByTestId('slideshow-modal-insert')).toBeInTheDocument()
+  })
+
+  it('insert button is disabled when no images selected', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.getByTestId('slideshow-modal-insert')).toBeDisabled()
+  })
+
+  it('insert button is enabled when at least one image is selected', () => {
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    expect(screen.getByTestId('slideshow-modal-insert')).not.toBeDisabled()
+  })
+
+  it('clicking pick-image-button calls onRequestImagePick', () => {
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    expect(onRequestImagePick).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it('after image picked, thumbnail is shown and pick button label changes to Change', () => {
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    expect(screen.getByTestId('slide-thumb-0')).toHaveAttribute(
+      'src',
+      'https://example.com/photo.jpg',
+    )
+    expect(screen.getByTestId('pick-image-button-0')).toHaveTextContent(
+      'Change',
+    )
+  })
+
+  it('changing alt text updates state', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('alt-text-input-0'), {
+      target: { value: 'A beautiful sunset' },
+    })
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue(
+      'A beautiful sunset',
+    )
+  })
+
+  it('changing caption updates state', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('caption-input-0'), {
+      target: { value: 'Sunset over the hills' },
+    })
+    expect(screen.getByTestId('caption-input-0')).toHaveValue(
+      'Sunset over the hills',
+    )
+  })
+
+  it('toggling caption-pos-checkbox changes captionPos to top and back', () => {
+    const onInsert = jest.fn()
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    fireEvent.change(screen.getByTestId('caption-input-0'), {
+      target: { value: 'My caption' },
+    })
+    fireEvent.click(screen.getByTestId('caption-pos-checkbox-0'))
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert'))
+    expect((onInsert.mock.calls[0] as [string])[0]).toContain('caption-pos=top')
+  })
+
+  it('toggling caption-pos-checkbox back removes caption-pos=top', () => {
+    const onInsert = jest.fn()
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    fireEvent.click(screen.getByTestId('caption-pos-checkbox-0'))
+    fireEvent.click(screen.getByTestId('caption-pos-checkbox-0'))
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert'))
+    expect((onInsert.mock.calls[0] as [string])[0]).not.toContain(
+      'caption-pos=top',
+    )
+  })
+
+  it('toggling expand-checkbox changes expand', () => {
+    const onInsert = jest.fn()
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    fireEvent.click(screen.getByTestId('expand-checkbox-0'))
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert'))
+    expect((onInsert.mock.calls[0] as [string])[0]).toContain('expand=true')
+  })
+
+  it('toggling photo-meta-checkbox shows photo meta inputs', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('photo-iso-input-0')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('photo-meta-checkbox-0'))
+    expect(screen.getByTestId('photo-iso-input-0')).toBeInTheDocument()
+    expect(screen.getByTestId('photo-aperture-input-0')).toBeInTheDocument()
+    expect(screen.getByTestId('photo-exposure-input-0')).toBeInTheDocument()
+    expect(screen.getByTestId('photo-focal-length-input-0')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('photo-panoramic-count-input-0'),
+    ).toBeInTheDocument()
+  })
+
+  it('toggling photo-meta-checkbox off hides photo meta inputs', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('photo-meta-checkbox-0'))
+    fireEvent.click(screen.getByTestId('photo-meta-checkbox-0'))
+    expect(screen.queryByTestId('photo-iso-input-0')).not.toBeInTheDocument()
+  })
+
+  it('photo meta inputs update state', () => {
+    const onInsert = jest.fn()
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    fireEvent.click(screen.getByTestId('photo-meta-checkbox-0'))
+    fireEvent.change(screen.getByTestId('photo-iso-input-0'), {
+      target: { value: '800' },
+    })
+    fireEvent.change(screen.getByTestId('photo-aperture-input-0'), {
+      target: { value: 'f/4' },
+    })
+    fireEvent.change(screen.getByTestId('photo-exposure-input-0'), {
+      target: { value: '1/500' },
+    })
+    fireEvent.change(screen.getByTestId('photo-panoramic-count-input-0'), {
+      target: { value: '5' },
+    })
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert'))
+    const inserted = (onInsert.mock.calls[0] as [string])[0]
+    expect(inserted).toContain('photo-iso=800')
+    expect(inserted).toContain('photo-aperture=f/4')
+    expect(inserted).toContain('photo-exposure=1/500')
+    expect(inserted).toContain('photo-panoramic-count=5')
+  })
+
+  it('focal length input accepts number value', () => {
+    const onInsert = jest.fn()
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    fireEvent.click(screen.getByTestId('photo-meta-checkbox-0'))
+    fireEvent.change(screen.getByTestId('photo-focal-length-input-0'), {
+      target: { value: '50' },
+    })
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert'))
+    expect((onInsert.mock.calls[0] as [string])[0]).toContain(
+      'photo-focal-length=50mm',
+    )
+  })
+
+  it('clicking add-slide-button adds a second slide card', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('slide-card-1')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('add-slide-button'))
+    expect(screen.getByTestId('slide-card-1')).toBeInTheDocument()
+  })
+
+  it('remove-slide button NOT shown when only 1 slide', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('remove-slide-0')).not.toBeInTheDocument()
+  })
+
+  it('remove-slide-1 button appears on second slide, clicking removes it', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('add-slide-button'))
+    expect(screen.getByTestId('remove-slide-1')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('remove-slide-1'))
+    expect(screen.queryByTestId('slide-card-1')).not.toBeInTheDocument()
+  })
+
+  it('move-up-0 is disabled on first slide', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.getByTestId('move-up-0')).toBeDisabled()
+  })
+
+  it('move-down is disabled on last slide', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.getByTestId('move-down-0')).toBeDisabled()
+  })
+
+  it('move-up swaps slide with the one above', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('add-slide-button'))
+    fireEvent.change(screen.getByTestId('alt-text-input-0'), {
+      target: { value: 'First' },
+    })
+    fireEvent.change(screen.getByTestId('alt-text-input-1'), {
+      target: { value: 'Second' },
+    })
+    fireEvent.click(screen.getByTestId('move-up-1'))
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue('Second')
+    expect(screen.getByTestId('alt-text-input-1')).toHaveValue('First')
+  })
+
+  it('move-down swaps slide with the one below', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('add-slide-button'))
+    fireEvent.change(screen.getByTestId('alt-text-input-0'), {
+      target: { value: 'First' },
+    })
+    fireEvent.change(screen.getByTestId('alt-text-input-1'), {
+      target: { value: 'Second' },
+    })
+    fireEvent.click(screen.getByTestId('move-down-0'))
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue('Second')
+    expect(screen.getByTestId('alt-text-input-1')).toHaveValue('First')
+  })
+
+  it('insert-after-0 button appears between slides and inserts a new slide', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('add-slide-button'))
+    fireEvent.change(screen.getByTestId('alt-text-input-1'), {
+      target: { value: 'Was second' },
+    })
+    expect(screen.getByTestId('insert-after-0')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('insert-after-0'))
+    expect(screen.getAllByTestId(/^slide-card-/)).toHaveLength(3)
+    expect(screen.getByTestId('alt-text-input-2')).toHaveValue('Was second')
+  })
+
+  it('insert-after button not shown when only 1 slide', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('insert-after-0')).not.toBeInTheDocument()
+  })
+
+  it('updating second slide does not affect first slide', () => {
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    // Add second slide
+    fireEvent.click(screen.getByTestId('add-slide-button'))
+    // Update the second slide alt text
+    fireEvent.change(screen.getByTestId('alt-text-input-1'), {
+      target: { value: 'Second slide alt' },
+    })
+    // First slide should not be affected
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue('')
+    expect(screen.getByTestId('alt-text-input-1')).toHaveValue(
+      'Second slide alt',
+    )
+  })
+
+  it('slideshow-preview not shown when no images selected', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('slideshow-preview')).not.toBeInTheDocument()
+  })
+
+  it('slideshow-preview shown with correct markdown when image is selected', () => {
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    expect(screen.getByTestId('slideshow-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('slideshow-preview').textContent).toContain(
+      '```slideshow',
+    )
+    expect(screen.getByTestId('slideshow-preview').textContent).toContain(
+      'https://example.com/photo.jpg',
+    )
+  })
+
+  it('clicking insert calls onInsert with correct markdown and resets form', () => {
+    const onInsert = jest.fn()
+    const onRequestImagePick = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={onRequestImagePick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('pick-image-button-0'))
+    pickImageForSlide(onRequestImagePick)
+    fireEvent.click(screen.getByTestId('slideshow-modal-insert'))
+    expect(onInsert).toHaveBeenCalledWith(
+      '\n\n```slideshow\n![](https://example.com/photo.jpg)\n```\n\n',
+    )
+    // After insert, form resets to single empty slide
+    expect(screen.queryByTestId('slide-thumb-0')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('slideshow-preview')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('slide-card-1')).not.toBeInTheDocument()
+  })
+
+  it('clicking cancel calls onCancel', () => {
+    const onCancel = jest.fn()
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={onCancel}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('slideshow-modal-cancel'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SlideshowInsertModal initialValues', () => {
+  it('pre-populates slides from initialValues', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+        initialValues={{
+          slides: [
+            {
+              url: 'https://cdn.com/slide1.jpg',
+              altText: 'Slide 1 alt',
+              caption: 'Slide 1 caption',
+              captionPos: 'bottom',
+              size: 'full',
+              align: 'none',
+              expand: true,
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByTestId('slide-thumb-0')).toHaveAttribute(
+      'src',
+      'https://cdn.com/slide1.jpg',
+    )
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue('Slide 1 alt')
+    expect(screen.getByTestId('caption-input-0')).toHaveValue('Slide 1 caption')
+    expect(screen.getByTestId('expand-checkbox-0')).toBeChecked()
+  })
+
+  it('pre-populates photo meta from initialValues', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+        initialValues={{
+          slides: [
+            {
+              url: 'https://cdn.com/slide1.jpg',
+              altText: '',
+              caption: '',
+              captionPos: 'bottom',
+              size: 'full',
+              align: 'none',
+              expand: false,
+              photoMeta: {
+                iso: '400',
+                aperture: 'f/2.8',
+                exposure: '1/250',
+                focalLength: '50mm',
+                panoramicCount: '3',
+              },
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByTestId('photo-meta-checkbox-0')).toBeChecked()
+    expect(screen.getByTestId('photo-iso-input-0')).toHaveValue('400')
+    expect(screen.getByTestId('photo-aperture-input-0')).toHaveValue('f/2.8')
+    expect(screen.getByTestId('photo-exposure-input-0')).toHaveValue('1/250')
+    expect(screen.getByTestId('photo-focal-length-input-0')).toHaveValue(50)
+    expect(screen.getByTestId('photo-panoramic-count-input-0')).toHaveValue('3')
+  })
+
+  it('does not pre-fill when initialValues is null', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+        initialValues={null}
+      />,
+    )
+    expect(screen.queryByTestId('slide-thumb-0')).not.toBeInTheDocument()
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue('')
+  })
+
+  it('insert button enabled when initialValues provides image url', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+        initialValues={{
+          slides: [
+            {
+              url: 'https://cdn.com/slide1.jpg',
+              altText: '',
+              caption: '',
+              captionPos: 'bottom',
+              size: 'full',
+              align: 'none',
+              expand: false,
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByTestId('slideshow-modal-insert')).not.toBeDisabled()
+  })
+
+  it('uses defaults when initialValues slide fields are undefined', () => {
+    renderApp(
+      <SlideshowInsertModal
+        isOpen
+        onInsert={jest.fn()}
+        onCancel={jest.fn()}
+        pickerOpen={false}
+        onRequestImagePick={jest.fn()}
+        initialValues={{
+          slides: [
+            {
+              url: 'https://cdn.com/slide1.jpg',
+              altText: undefined as unknown as string,
+              caption: undefined as unknown as string,
+              captionPos: undefined as unknown as 'top' | 'bottom',
+              expand: undefined as unknown as boolean,
+              size: 'full',
+              align: 'none',
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByTestId('alt-text-input-0')).toHaveValue('')
+    expect(screen.getByTestId('caption-input-0')).toHaveValue('')
+    expect(screen.getByTestId('caption-pos-checkbox-0')).not.toBeChecked()
+    expect(screen.getByTestId('expand-checkbox-0')).not.toBeChecked()
+  })
+})

--- a/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/SlideshowInsertModal.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/SlideshowInsertModal.styles.ts
@@ -1,0 +1,336 @@
+import { Modal as ModalOverlays } from 'react-overlays'
+import styled from 'styled-components'
+
+import { Button } from '@sdlgr/button'
+
+export const StyledBackdrop = styled.div`
+  position: fixed;
+  z-index: 1040;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: ${({ theme }) => theme.colors.black};
+  opacity: 0.7;
+`
+
+export const StyledSlideshowInsertModal = styled(ModalOverlays)`
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: 1040;
+  border: 1px solid ${({ theme }) => theme.colors.green};
+  box-shadow: 0 0 16px 4px rgba(152, 223, 214, 0.5);
+  border-radius: 2px;
+  background-color: ${({ theme }) => theme.colors.black};
+  overflow-y: auto;
+
+  ${({ theme }) => theme.media.up.md} {
+    top: 5vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    height: auto;
+    max-width: min(720px, 90vw);
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+`
+
+export const StyledModalContent = styled.div`
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`
+
+export const StyledModalTitle = styled.h2`
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: ${({ theme }) => theme.colors.green};
+  margin: 0;
+`
+
+export const StyledLabel = styled.label`
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.7;
+  color: ${({ theme }) => theme.colors.white};
+`
+
+export const StyledInput = styled.input`
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  color: ${({ theme }) => theme.colors.white};
+  font-family: inherit;
+  font-size: 0.8rem;
+  padding: 0.45rem 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+
+  &::placeholder {
+    opacity: 0.35;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledSlideCard = styled.div`
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`
+
+export const StyledSlideCardHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`
+
+export const StyledSlideNumber = styled.span`
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: ${({ theme }) => theme.colors.green};
+  opacity: 0.8;
+`
+
+export const StyledSlideHeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+`
+
+export const StyledMoveButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  color: rgba(251, 251, 251, 0.35);
+  border-color: transparent;
+  font-size: 0.7rem;
+  padding: 0.15rem 0.35rem;
+  min-width: unset;
+
+  &:hover:not(:disabled) {
+    color: ${({ theme }) => theme.colors.white};
+    border-color: rgba(251, 251, 251, 0.3);
+  }
+
+  &:disabled {
+    opacity: 0.15;
+    cursor: not-allowed;
+  }
+`
+
+export const StyledRemoveSlideButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  color: rgba(251, 251, 251, 0.4);
+  border-color: rgba(251, 251, 251, 0.15);
+  font-size: 0.65rem;
+  padding: 0.2rem 0.5rem;
+
+  &:hover:not(:disabled) {
+    color: ${({ theme }) => theme.colors.white};
+    border-color: rgba(251, 251, 251, 0.5);
+  }
+`
+
+export const StyledInsertBetweenRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.25rem;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.07);
+  }
+`
+
+export const StyledInsertBetweenButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  border-color: rgba(152, 223, 214, 0.2);
+  color: ${({ theme }) => theme.colors.green};
+  font-size: 0.65rem;
+  opacity: 0.5;
+  padding: 0.1rem 0.5rem;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledImageSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  min-height: 64px;
+`
+
+export const StyledImageThumb = styled.img`
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 2px;
+  flex-shrink: 0;
+`
+
+export const StyledImagePlaceholder = styled.div`
+  flex: 1;
+  font-size: 0.78rem;
+  opacity: 0.35;
+  color: ${({ theme }) => theme.colors.white};
+`
+
+export const StyledPickButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  border-color: rgba(128, 128, 128, 0.35);
+  border-radius: 4px;
+  color: ${({ theme }) => theme.colors.white};
+  font-size: 0.72rem;
+  opacity: 0.75;
+  padding: 0.4rem 0.7rem;
+  white-space: nowrap;
+  margin-left: auto;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledCheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  opacity: 0.85;
+  color: ${({ theme }) => theme.colors.white};
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+  }
+
+  input[type='checkbox'] {
+    cursor: pointer;
+    accent-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledPhotoMetaInputRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0.5rem;
+`
+
+export const StyledPhotoMetaField = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+`
+
+export const StyledAddSlideButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  align-self: flex-start;
+  border-color: rgba(152, 223, 214, 0.3);
+  color: ${({ theme }) => theme.colors.green};
+  font-size: 0.72rem;
+  opacity: 0.75;
+  padding: 0.4rem 0.9rem;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledPreview = styled.pre`
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  margin: 0;
+  max-height: 4rem;
+  opacity: 0.7;
+  overflow: auto;
+  padding: 0.6rem 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+`
+
+export const StyledButtons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+`
+
+export const StyledCancelButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  padding: 0.375rem 0.875rem;
+  color: ${({ theme }) => theme.colors.white};
+  border-color: rgba(255, 255, 255, 0.25);
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  &:hover {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+`
+
+export const StyledInsertButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  padding: 0.375rem 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${({ theme }) => theme.colors.green};
+  border-color: ${({ theme }) => theme.colors.green};
+
+  &:hover:not(:disabled) {
+    box-shadow: 0 0 8px 1px rgba(152, 223, 214, 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+`

--- a/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/SlideshowInsertModal.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/SlideshowInsertModal.tsx
@@ -1,0 +1,527 @@
+'use client'
+
+import React, { useRef, useState } from 'react'
+import { RenderModalBackdropProps } from 'react-overlays/Modal'
+
+import { Select } from '@sdlgr/select'
+
+import type { CloudinaryImage } from '@web/lib/cloudinary/images'
+
+import type {
+  ParsedSlideshow,
+  ParsedSlideshowSlide,
+} from '../PostEditor/parseEmbedBlock'
+import {
+  StyledAddSlideButton,
+  StyledBackdrop,
+  StyledButtons,
+  StyledCancelButton,
+  StyledCheckboxRow,
+  StyledImagePlaceholder,
+  StyledImageSection,
+  StyledImageThumb,
+  StyledInput,
+  StyledInsertBetweenButton,
+  StyledInsertBetweenRow,
+  StyledInsertButton,
+  StyledLabel,
+  StyledModalContent,
+  StyledModalTitle,
+  StyledMoveButton,
+  StyledPhotoMetaField,
+  StyledPhotoMetaInputRow,
+  StyledPickButton,
+  StyledPreview,
+  StyledRemoveSlideButton,
+  StyledSlideCard,
+  StyledSlideCardHeader,
+  StyledSlideHeaderActions,
+  StyledSlideNumber,
+  StyledSlideshowInsertModal,
+} from './SlideshowInsertModal.styles'
+
+const ISO_OPTIONS = [
+  '100',
+  '200',
+  '400',
+  '800',
+  '1600',
+  '3200',
+  '6400',
+  '12800',
+  '25600',
+  '51200',
+].map((v) => ({ value: v, label: v }))
+
+const APERTURE_OPTIONS = [
+  'f/1.4',
+  'f/1.8',
+  'f/2',
+  'f/2.8',
+  'f/4',
+  'f/5.6',
+  'f/8',
+  'f/9',
+  'f/10',
+  'f/11',
+  'f/16',
+  'f/22',
+].map((v) => ({ value: v, label: v }))
+
+const SHUTTER_SPEED_OPTIONS = [
+  '1/8000',
+  '1/4000',
+  '1/2000',
+  '1/1000',
+  '1/500',
+  '1/400',
+  '1/320',
+  '1/250',
+  '1/125',
+  '1/60',
+  '1/30',
+  '1/15',
+  '1/8',
+  '1/4',
+  '1/2',
+  '1s',
+  '2s',
+  '5s',
+  '10s',
+  '30s',
+].map((v) => ({ value: v, label: v }))
+
+export interface SlideState {
+  id: string
+  selectedImage: CloudinaryImage | null
+  altText: string
+  caption: string
+  captionPos: 'top' | 'bottom'
+  expand: boolean
+  photoMetaEnabled: boolean
+  photoIso: string
+  photoExposure: string
+  photoAperture: string
+  photoFocalLength: string
+  photoPanoramicCount: string
+}
+
+function makeDefaultSlide(id: string): SlideState {
+  return {
+    id,
+    selectedImage: null,
+    altText: '',
+    caption: '',
+    captionPos: 'bottom',
+    expand: false,
+    photoMetaEnabled: false,
+    photoIso: '',
+    photoExposure: '',
+    photoAperture: '',
+    photoFocalLength: '',
+    photoPanoramicCount: '',
+  }
+}
+
+function makeSlideFromParsed(s: ParsedSlideshowSlide, id: string): SlideState {
+  return {
+    id,
+    selectedImage: { url: s.url } as unknown as CloudinaryImage,
+    altText: s.altText ?? '',
+    caption: s.caption ?? '',
+    captionPos: s.captionPos ?? 'bottom',
+    expand: s.expand ?? false,
+    photoMetaEnabled: !!(
+      s.photoMeta?.iso ||
+      s.photoMeta?.aperture ||
+      s.photoMeta?.exposure ||
+      s.photoMeta?.focalLength ||
+      s.photoMeta?.panoramicCount
+    ),
+    photoIso: s.photoMeta?.iso ?? '',
+    photoExposure: s.photoMeta?.exposure ?? '',
+    photoAperture: s.photoMeta?.aperture ?? '',
+    photoFocalLength: s.photoMeta?.focalLength?.replace(/mm$/, '') ?? '',
+    photoPanoramicCount: s.photoMeta?.panoramicCount ?? '',
+  }
+}
+
+export function buildSlideMarkdown(slide: SlideState): string | null {
+  if (!slide.selectedImage) return null
+  const parts: string[] = []
+  if (slide.caption.trim()) {
+    parts.push(`caption=${slide.caption.trim()}`)
+    if (slide.captionPos === 'top') parts.push('caption-pos=top')
+  }
+  if (slide.altText.trim()) parts.push(`alt=${slide.altText.trim()}`)
+  if (slide.expand) parts.push('expand=true')
+  if (slide.photoMetaEnabled) {
+    if (slide.photoIso.trim()) parts.push(`photo-iso=${slide.photoIso.trim()}`)
+    if (slide.photoAperture.trim())
+      parts.push(`photo-aperture=${slide.photoAperture.trim()}`)
+    if (slide.photoExposure.trim())
+      parts.push(`photo-exposure=${slide.photoExposure.trim()}`)
+    if (slide.photoFocalLength)
+      parts.push(`photo-focal-length=${slide.photoFocalLength}mm`)
+    if (slide.photoPanoramicCount.trim())
+      parts.push(`photo-panoramic-count=${slide.photoPanoramicCount.trim()}`)
+  }
+  const params = parts.join('&')
+  return `![${params}](${slide.selectedImage.url})`
+}
+
+export function buildSlideshowMarkdown(slides: SlideState[]): string {
+  const lines = slides
+    .map(buildSlideMarkdown)
+    .filter((l): l is string => l !== null)
+    .join('\n')
+  if (!lines) return ''
+  return `\n\n\`\`\`slideshow\n${lines}\n\`\`\`\n\n`
+}
+
+export interface SlideshowInsertModalProps {
+  isOpen: boolean
+  onInsert: (markdown: string) => void
+  onCancel: () => void
+  pickerOpen: boolean
+  onRequestImagePick: (onPicked: (image: CloudinaryImage) => void) => void
+  initialValues?: ParsedSlideshow | null
+}
+
+export function SlideshowInsertModal({
+  isOpen,
+  onInsert,
+  onCancel,
+  pickerOpen,
+  onRequestImagePick,
+  initialValues,
+}: SlideshowInsertModalProps) {
+  const [slides, setSlides] = useState<SlideState[]>(() => {
+    if (!initialValues?.slides.length) return [makeDefaultSlide('0')]
+    return initialValues.slides.map((s, i) => makeSlideFromParsed(s, String(i)))
+  })
+
+  const idRef = useRef(slides.length)
+
+  function nextId(): string {
+    const id = String(idRef.current)
+    idRef.current += 1
+    return id
+  }
+
+  function updateSlide(index: number, update: Partial<SlideState>) {
+    setSlides((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, ...update } : s)),
+    )
+  }
+
+  function addSlide() {
+    setSlides((prev) => [...prev, makeDefaultSlide(nextId())])
+  }
+
+  function moveSlide(index: number, direction: 'up' | 'down') {
+    const target = direction === 'up' ? index - 1 : index + 1
+    setSlides((prev) => {
+      const next = [...prev]
+      ;[next[index], next[target]] = [next[target], next[index]]
+      return next
+    })
+  }
+
+  function insertSlideAt(afterIndex: number) {
+    setSlides((prev) => [
+      ...prev.slice(0, afterIndex + 1),
+      makeDefaultSlide(nextId()),
+      ...prev.slice(afterIndex + 1),
+    ])
+  }
+
+  function removeSlide(index: number) {
+    /* istanbul ignore next */
+    if (slides.length <= 1) return
+    setSlides((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  function handleInsert() {
+    const markdown = buildSlideshowMarkdown(slides)
+    onInsert(markdown)
+    setSlides([makeDefaultSlide(nextId())])
+  }
+
+  const hasAnyImage = slides.some((s) => s.selectedImage !== null)
+  const preview = hasAnyImage ? buildSlideshowMarkdown(slides).trim() : null
+
+  return (
+    <StyledSlideshowInsertModal
+      show={isOpen}
+      onHide={onCancel}
+      enforceFocus={!pickerOpen}
+      renderBackdrop={
+        pickerOpen
+          ? undefined
+          : (props: RenderModalBackdropProps) => <StyledBackdrop {...props} />
+      }
+      aria-labelledby="slideshow-insert-modal"
+    >
+      <StyledModalContent>
+        <StyledModalTitle>Insert Slideshow</StyledModalTitle>
+
+        {slides.map((slide, index) => (
+          <React.Fragment key={slide.id}>
+            <StyledSlideCard data-testid={`slide-card-${index}`}>
+              <StyledSlideCardHeader>
+                <StyledSlideNumber>Slide {index + 1}</StyledSlideNumber>
+                <StyledSlideHeaderActions>
+                  <StyledMoveButton
+                    type="button"
+                    onClick={() => moveSlide(index, 'up')}
+                    disabled={index === 0}
+                    aria-label="Move slide up"
+                    data-testid={`move-up-${index}`}
+                  >
+                    ↑
+                  </StyledMoveButton>
+                  <StyledMoveButton
+                    type="button"
+                    onClick={() => moveSlide(index, 'down')}
+                    disabled={index === slides.length - 1}
+                    aria-label="Move slide down"
+                    data-testid={`move-down-${index}`}
+                  >
+                    ↓
+                  </StyledMoveButton>
+                  {slides.length > 1 && (
+                    <StyledRemoveSlideButton
+                      type="button"
+                      onClick={() => removeSlide(index)}
+                      data-testid={`remove-slide-${index}`}
+                    >
+                      Remove
+                    </StyledRemoveSlideButton>
+                  )}
+                </StyledSlideHeaderActions>
+              </StyledSlideCardHeader>
+
+              <StyledImageSection>
+                {slide.selectedImage ? (
+                  <StyledImageThumb
+                    src={slide.selectedImage.url}
+                    alt="Selected"
+                    data-testid={`slide-thumb-${index}`}
+                  />
+                ) : (
+                  <StyledImagePlaceholder>
+                    No image selected
+                  </StyledImagePlaceholder>
+                )}
+                <StyledPickButton
+                  type="button"
+                  onClick={() =>
+                    onRequestImagePick((img) =>
+                      updateSlide(index, { selectedImage: img }),
+                    )
+                  }
+                  data-testid={`pick-image-button-${index}`}
+                >
+                  {slide.selectedImage ? 'Change' : 'Pick image'}
+                </StyledPickButton>
+              </StyledImageSection>
+
+              <StyledLabel htmlFor={`slide-${index}-alt`}>Alt text</StyledLabel>
+              <StyledInput
+                id={`slide-${index}-alt`}
+                value={slide.altText}
+                onChange={(e) =>
+                  updateSlide(index, { altText: e.target.value })
+                }
+                placeholder="Describe the image for accessibility"
+                data-testid={`alt-text-input-${index}`}
+              />
+
+              <StyledLabel htmlFor={`slide-${index}-caption`}>
+                Caption
+              </StyledLabel>
+              <StyledInput
+                id={`slide-${index}-caption`}
+                value={slide.caption}
+                onChange={(e) =>
+                  updateSlide(index, { caption: e.target.value })
+                }
+                placeholder="Optional caption"
+                data-testid={`caption-input-${index}`}
+              />
+
+              <StyledCheckboxRow>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={slide.captionPos === 'top'}
+                    onChange={(e) =>
+                      updateSlide(index, {
+                        captionPos: e.target.checked ? 'top' : 'bottom',
+                      })
+                    }
+                    data-testid={`caption-pos-checkbox-${index}`}
+                  />
+                  Caption above image
+                </label>
+              </StyledCheckboxRow>
+
+              <StyledCheckboxRow>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={slide.expand}
+                    onChange={(e) =>
+                      updateSlide(index, { expand: e.target.checked })
+                    }
+                    data-testid={`expand-checkbox-${index}`}
+                  />
+                  Expand on click
+                </label>
+              </StyledCheckboxRow>
+
+              <StyledCheckboxRow>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={slide.photoMetaEnabled}
+                    onChange={(e) =>
+                      updateSlide(index, { photoMetaEnabled: e.target.checked })
+                    }
+                    data-testid={`photo-meta-checkbox-${index}`}
+                  />
+                  Photo metadata
+                </label>
+              </StyledCheckboxRow>
+
+              {slide.photoMetaEnabled && (
+                <StyledPhotoMetaInputRow>
+                  <StyledPhotoMetaField>
+                    <StyledLabel htmlFor={`slide-${index}-iso`}>
+                      ISO
+                    </StyledLabel>
+                    <Select
+                      id={`slide-${index}-iso`}
+                      value={slide.photoIso}
+                      onChange={(v) => updateSlide(index, { photoIso: v })}
+                      options={ISO_OPTIONS}
+                      isSearchable
+                      isClearable
+                      placeholder="e.g. 400"
+                      data-testid={`photo-iso-input-${index}`}
+                    />
+                  </StyledPhotoMetaField>
+                  <StyledPhotoMetaField>
+                    <StyledLabel htmlFor={`slide-${index}-aperture`}>
+                      Aperture
+                    </StyledLabel>
+                    <Select
+                      id={`slide-${index}-aperture`}
+                      value={slide.photoAperture}
+                      onChange={(v) => updateSlide(index, { photoAperture: v })}
+                      options={APERTURE_OPTIONS}
+                      isSearchable
+                      isClearable
+                      placeholder="e.g. f/2.8"
+                      data-testid={`photo-aperture-input-${index}`}
+                    />
+                  </StyledPhotoMetaField>
+                  <StyledPhotoMetaField>
+                    <StyledLabel htmlFor={`slide-${index}-exposure`}>
+                      Shutter speed
+                    </StyledLabel>
+                    <Select
+                      id={`slide-${index}-exposure`}
+                      value={slide.photoExposure}
+                      onChange={(v) => updateSlide(index, { photoExposure: v })}
+                      options={SHUTTER_SPEED_OPTIONS}
+                      isSearchable
+                      isClearable
+                      placeholder="e.g. 1/250"
+                      data-testid={`photo-exposure-input-${index}`}
+                    />
+                  </StyledPhotoMetaField>
+                  <StyledPhotoMetaField>
+                    <StyledLabel htmlFor={`slide-${index}-focal`}>
+                      Focal length
+                    </StyledLabel>
+                    <StyledInput
+                      id={`slide-${index}-focal`}
+                      type="number"
+                      min="1"
+                      value={slide.photoFocalLength}
+                      onChange={(e) =>
+                        updateSlide(index, { photoFocalLength: e.target.value })
+                      }
+                      placeholder="e.g. 50"
+                      data-testid={`photo-focal-length-input-${index}`}
+                    />
+                  </StyledPhotoMetaField>
+                  <StyledPhotoMetaField>
+                    <StyledLabel htmlFor={`slide-${index}-panoramic`}>
+                      Panoramic shots
+                    </StyledLabel>
+                    <StyledInput
+                      id={`slide-${index}-panoramic`}
+                      value={slide.photoPanoramicCount}
+                      onChange={(e) =>
+                        updateSlide(index, {
+                          photoPanoramicCount: e.target.value,
+                        })
+                      }
+                      placeholder="e.g. 12"
+                      data-testid={`photo-panoramic-count-input-${index}`}
+                    />
+                  </StyledPhotoMetaField>
+                </StyledPhotoMetaInputRow>
+              )}
+            </StyledSlideCard>
+
+            {index < slides.length - 1 && (
+              <StyledInsertBetweenRow>
+                <StyledInsertBetweenButton
+                  type="button"
+                  onClick={() => insertSlideAt(index)}
+                  data-testid={`insert-after-${index}`}
+                >
+                  + Insert here
+                </StyledInsertBetweenButton>
+              </StyledInsertBetweenRow>
+            )}
+          </React.Fragment>
+        ))}
+
+        <StyledAddSlideButton
+          type="button"
+          onClick={addSlide}
+          data-testid="add-slide-button"
+        >
+          + Add slide
+        </StyledAddSlideButton>
+
+        {preview && (
+          <StyledPreview data-testid="slideshow-preview">
+            {preview}
+          </StyledPreview>
+        )}
+
+        <StyledButtons>
+          <StyledCancelButton
+            onClick={onCancel}
+            data-testid="slideshow-modal-cancel"
+          >
+            Cancel
+          </StyledCancelButton>
+          <StyledInsertButton
+            onClick={handleInsert}
+            disabled={!hasAnyImage}
+            data-testid="slideshow-modal-insert"
+          >
+            Insert
+          </StyledInsertButton>
+        </StyledButtons>
+      </StyledModalContent>
+    </StyledSlideshowInsertModal>
+  )
+}

--- a/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/index.ts
+++ b/apps/web/app/admin/(auth)/posts/components/SlideshowInsertModal/index.ts
@@ -1,0 +1,2 @@
+export { SlideshowInsertModal } from './SlideshowInsertModal'
+export type { SlideshowInsertModalProps } from './SlideshowInsertModal'

--- a/apps/web/components/PostContent/PostContentSlideshow.spec.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.spec.tsx
@@ -1,0 +1,336 @@
+import { fireEvent, screen } from '@testing-library/react'
+import ReactDOM from 'react-dom'
+
+import { renderWithTheme } from '@sdlgr/test-utils'
+
+import { PostContentSlideshow } from './PostContentSlideshow'
+
+jest.mock('@web/i18n/client', () => ({
+  useClientTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'photoMeta.iso': 'ISO',
+        'photoMeta.aperture': 'Aperture',
+        'photoMeta.exposure': 'Exposure',
+        'photoMeta.focalLength': 'Focal length',
+        'photoMeta.panoramicCount': 'Panoramic shots',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} />
+  ),
+}))
+
+jest.mock('react-dom', () => ({
+  ...jest.requireActual<typeof ReactDOM>('react-dom'),
+  createPortal: (node: React.ReactNode) => node,
+}))
+
+jest.mock('./PostContent.styles', () => ({
+  StyledCaption: ({ children }: { children: React.ReactNode }) => (
+    <figcaption data-testid="slideshow-caption">{children}</figcaption>
+  ),
+  StyledModalOverlay: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+  }) => (
+    <div data-testid="slideshow-image-modal" onClick={onClick}>
+      {children}
+    </div>
+  ),
+  StyledModalContent: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode
+    onClick?: (e: React.MouseEvent) => void
+  }) => (
+    <div data-testid="slideshow-modal-content" onClick={onClick}>
+      {children}
+    </div>
+  ),
+  StyledModalClose: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+  }) => (
+    <button data-testid="slideshow-modal-close" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  StyledModalDownload: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => (
+    <a data-testid="slideshow-modal-download" href={href}>
+      {children}
+    </a>
+  ),
+  StyledPhotoMeta: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="slideshow-photo-meta">{children}</div>
+  ),
+  StyledPhotoMetaItem: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="slideshow-photo-meta-item">{children}</div>
+  ),
+  StyledPhotoMetaLabel: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="slideshow-photo-meta-label">{children}</span>
+  ),
+}))
+
+const singleSlide = JSON.stringify([{ src: '/img1.jpg', alt: '' }])
+
+const twoSlides = JSON.stringify([
+  { src: '/img1.jpg', alt: '' },
+  { src: '/img2.jpg', alt: '' },
+])
+
+describe('PostContentSlideshow', () => {
+  it('returns null on invalid JSON', () => {
+    const { container } = renderWithTheme(
+      <PostContentSlideshow slides="not-valid-json" />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('returns null on empty slides array', () => {
+    const { container } = renderWithTheme(
+      <PostContentSlideshow slides={JSON.stringify([])} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders slideshow with single slide', () => {
+    renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
+    expect(screen.getByTestId('post-slideshow')).toBeInTheDocument()
+  })
+
+  it('shows counter "1 / 1" for single slide', () => {
+    renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
+    expect(screen.getByTestId('slideshow-counter')).toHaveTextContent('1 / 1')
+  })
+
+  it('prev button is disabled for first slide', () => {
+    renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
+    expect(screen.getByTestId('slideshow-prev')).toBeDisabled()
+  })
+
+  it('next button is disabled for last slide with single slide', () => {
+    renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
+    expect(screen.getByTestId('slideshow-next')).toBeDisabled()
+  })
+
+  it('shows next button enabled with multiple slides', () => {
+    renderWithTheme(<PostContentSlideshow slides={twoSlides} />)
+    expect(screen.getByTestId('slideshow-next')).not.toBeDisabled()
+  })
+
+  it('clicking next advances to slide 2', () => {
+    renderWithTheme(<PostContentSlideshow slides={twoSlides} />)
+    fireEvent.click(screen.getByTestId('slideshow-next'))
+    expect(screen.getByTestId('slideshow-counter')).toHaveTextContent('2 / 2')
+  })
+
+  it('clicking prev after next goes back to slide 1', () => {
+    renderWithTheme(<PostContentSlideshow slides={twoSlides} />)
+    fireEvent.click(screen.getByTestId('slideshow-next'))
+    fireEvent.click(screen.getByTestId('slideshow-prev'))
+    expect(screen.getByTestId('slideshow-counter')).toHaveTextContent('1 / 2')
+  })
+
+  it('shows caption at bottom by default', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img.jpg', alt: 'caption=My caption' },
+        ])}
+      />,
+    )
+    expect(screen.getByTestId('slideshow-caption')).toHaveTextContent(
+      'My caption',
+    )
+  })
+
+  it('shows caption at top when caption-pos=top', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          {
+            src: '/img.jpg',
+            alt: 'caption=Top caption&caption-pos=top',
+          },
+        ])}
+      />,
+    )
+    expect(screen.getByTestId('slideshow-caption')).toHaveTextContent(
+      'Top caption',
+    )
+  })
+
+  it('shows photo meta section when photo-iso is present', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([{ src: '/img.jpg', alt: 'photo-iso=400' }])}
+      />,
+    )
+    expect(screen.getByTestId('slideshow-photo-meta')).toBeInTheDocument()
+  })
+
+  it('shows iso, aperture, exposure, focal length and panoramic count values', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          {
+            src: '/img.jpg',
+            alt: 'photo-iso=400&photo-aperture=f/2.8&photo-exposure=1/250&photo-focal-length=50mm&photo-panoramic-count=3',
+          },
+        ])}
+      />,
+    )
+    expect(screen.getByText('400')).toBeInTheDocument()
+    expect(screen.getByText('f/2.8')).toBeInTheDocument()
+    expect(screen.getByText('1/250')).toBeInTheDocument()
+    expect(screen.getByText('50mm')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('does not show photo meta when no photo params', () => {
+    renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
+    expect(screen.queryByTestId('slideshow-photo-meta')).not.toBeInTheDocument()
+  })
+
+  it('expand=true makes image wrapper clickable and clicking opens modal', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img.jpg', alt: 'expand=true&alt=expandable' },
+        ])}
+      />,
+    )
+    expect(
+      screen.queryByTestId('slideshow-image-modal'),
+    ).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))
+    expect(screen.getByTestId('slideshow-image-modal')).toBeInTheDocument()
+  })
+
+  it('modal has close button and clicking close closes it', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img.jpg', alt: 'expand=true&alt=expandable' },
+        ])}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))
+    expect(screen.getByTestId('slideshow-modal-close')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('slideshow-modal-close'))
+    expect(
+      screen.queryByTestId('slideshow-image-modal'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('modal has download link', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img.jpg', alt: 'expand=true&alt=expandable' },
+        ])}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))
+    expect(screen.getByTestId('slideshow-modal-download')).toHaveAttribute(
+      'href',
+      '/img.jpg',
+    )
+  })
+
+  it('clicking image modal overlay closes it', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img.jpg', alt: 'expand=true&alt=expandable' },
+        ])}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))
+    fireEvent.click(screen.getByTestId('slideshow-image-modal'))
+    expect(
+      screen.queryByTestId('slideshow-image-modal'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('expand=false: clicking image wrapper does not open modal', () => {
+    renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
+    fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))
+    expect(
+      screen.queryByTestId('slideshow-image-modal'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('alt text from alt= param is used', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img.jpg', alt: 'alt=My description' },
+        ])}
+      />,
+    )
+    expect(screen.getByAltText('My description')).toBeInTheDocument()
+  })
+
+  it('alt text falls back to full alt string when no = in it', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([{ src: '/img.jpg', alt: 'plain alt text' }])}
+      />,
+    )
+    expect(screen.getByAltText('plain alt text')).toBeInTheDocument()
+  })
+
+  it('alt is empty string when options exist but no alt= key', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([{ src: '/img.jpg', alt: 'caption=foo' }])}
+      />,
+    )
+    expect(screen.getByAltText('')).toBeInTheDocument()
+  })
+
+  it('alt is empty string when alt field is absent from slide', () => {
+    renderWithTheme(
+      <PostContentSlideshow slides={JSON.stringify([{ src: '/img.jpg' }])} />,
+    )
+    expect(screen.getByAltText('')).toBeInTheDocument()
+  })
+
+  it('shows caption inside modal when caption and expand are set', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          {
+            src: '/img.jpg',
+            alt: 'expand=true&caption=Modal caption&alt=img',
+          },
+        ])}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))
+    const captions = screen.getAllByTestId('slideshow-caption')
+    const captionTexts = captions.map((c) => c.textContent)
+    expect(captionTexts).toContain('Modal caption')
+  })
+})

--- a/apps/web/components/PostContent/PostContentSlideshow.styles.ts
+++ b/apps/web/components/PostContent/PostContentSlideshow.styles.ts
@@ -1,0 +1,89 @@
+import styled, { css, keyframes } from 'styled-components'
+
+import { Button } from '@sdlgr/button'
+
+export const StyledSlideshow = styled.figure`
+  margin: 2rem 0;
+  width: 100%;
+  position: relative;
+`
+
+export const StyledSlideshowImageWrapper = styled.div<{
+  $expandable?: boolean
+}>`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+
+  ${({ $expandable }) => $expandable && `cursor: zoom-in;`}
+`
+
+const slideInFromRight = keyframes`
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+`
+
+const slideInFromLeft = keyframes`
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+`
+
+export const StyledSlideshowSlide = styled.div<{
+  $direction: 'next' | 'prev' | 'none'
+}>`
+  position: absolute;
+  inset: 0;
+
+  ${({ $direction }) => {
+    if ($direction === 'next')
+      return css`
+        animation: ${slideInFromRight} 0.35s ease;
+      `
+    if ($direction === 'prev')
+      return css`
+        animation: ${slideInFromLeft} 0.35s ease;
+      `
+    return ''
+  }}
+`
+
+export const StyledSlideshowNav = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.5rem 0 0.25rem;
+`
+
+export const StyledSlideshowArrow = styled(Button).attrs({ variant: 'text' })`
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.6;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    color: ${({ theme }) => theme.colors.green};
+  }
+
+  &:disabled {
+    opacity: 0.2;
+    cursor: not-allowed;
+  }
+
+  &::after {
+    display: none;
+  }
+`
+
+export const StyledSlideshowCounter = styled.span`
+  font-family: var(--font-roboto-mono);
+  font-size: 0.75rem;
+  color: rgba(251, 251, 251, 0.5);
+  min-width: 3rem;
+  text-align: center;
+`

--- a/apps/web/components/PostContent/PostContentSlideshow.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import Image from 'next/image'
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import { useClientTranslation } from '@web/i18n/client'
+
+import {
+  StyledCaption,
+  StyledModalClose,
+  StyledModalContent,
+  StyledModalDownload,
+  StyledModalOverlay,
+  StyledPhotoMeta,
+  StyledPhotoMetaItem,
+  StyledPhotoMetaLabel,
+} from './PostContent.styles'
+import {
+  StyledSlideshow,
+  StyledSlideshowArrow,
+  StyledSlideshowCounter,
+  StyledSlideshowImageWrapper,
+  StyledSlideshowNav,
+  StyledSlideshowSlide,
+} from './PostContentSlideshow.styles'
+
+interface Slide {
+  src: string
+  alt: string
+}
+
+export function PostContentSlideshow({
+  slides: slidesJson,
+}: {
+  slides: string
+}) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [direction, setDirection] = useState<'next' | 'prev' | 'none'>('none')
+  const [expanded, setExpanded] = useState(false)
+  const { t } = useClientTranslation('common')
+
+  let slides: Slide[] = []
+  try {
+    slides = JSON.parse(slidesJson) as Slide[]
+  } catch {
+    return null
+  }
+
+  if (!slides.length) return null
+
+  const current = slides[currentIndex]
+  const options = current.alt?.includes('=')
+    ? new URLSearchParams(current.alt)
+    : null
+  const caption = options?.get('caption')
+  const captionPos = options?.get('caption-pos') ?? 'bottom'
+  const cleanAlt = options?.get('alt') ?? (options ? '' : (current.alt ?? ''))
+  const expandable = options?.get('expand') === 'true'
+  const photoIso = options?.get('photo-iso')
+  const photoAperture = options?.get('photo-aperture')
+  const photoExposure = options?.get('photo-exposure')
+  const photoFocalLength = options?.get('photo-focal-length')
+  const photoPanoramicCount = options?.get('photo-panoramic-count')
+  const hasPhotoMeta = !!(
+    photoIso ||
+    photoAperture ||
+    photoExposure ||
+    photoFocalLength ||
+    photoPanoramicCount
+  )
+
+  const canGoPrev = currentIndex > 0
+  const canGoNext = currentIndex < slides.length - 1
+
+  function goPrev() {
+    setDirection('prev')
+    setCurrentIndex((i) => i - 1)
+  }
+
+  function goNext() {
+    setDirection('next')
+    setCurrentIndex((i) => i + 1)
+  }
+
+  return (
+    <>
+      <StyledSlideshow data-testid="post-slideshow">
+        {caption && captionPos === 'top' && (
+          <StyledCaption data-testid="slideshow-caption">
+            {caption}
+          </StyledCaption>
+        )}
+        <StyledSlideshowImageWrapper
+          $expandable={expandable}
+          onClick={expandable ? () => setExpanded(true) : undefined}
+          data-testid="slideshow-image-wrapper"
+        >
+          <StyledSlideshowSlide key={currentIndex} $direction={direction}>
+            <Image
+              src={current.src}
+              alt={cleanAlt}
+              fill
+              sizes="(max-width: 1440px) 100vw, 1440px"
+              style={{ objectFit: 'contain' }}
+            />
+          </StyledSlideshowSlide>
+        </StyledSlideshowImageWrapper>
+        {hasPhotoMeta && (
+          <StyledPhotoMeta data-testid="slideshow-photo-meta">
+            {photoIso && (
+              <StyledPhotoMetaItem>
+                <StyledPhotoMetaLabel>
+                  {t('photoMeta.iso')}
+                </StyledPhotoMetaLabel>
+                <span>{photoIso}</span>
+              </StyledPhotoMetaItem>
+            )}
+            {photoAperture && (
+              <StyledPhotoMetaItem>
+                <StyledPhotoMetaLabel>
+                  {t('photoMeta.aperture')}
+                </StyledPhotoMetaLabel>
+                <span>{photoAperture}</span>
+              </StyledPhotoMetaItem>
+            )}
+            {photoExposure && (
+              <StyledPhotoMetaItem>
+                <StyledPhotoMetaLabel>
+                  {t('photoMeta.exposure')}
+                </StyledPhotoMetaLabel>
+                <span>{photoExposure}</span>
+              </StyledPhotoMetaItem>
+            )}
+            {photoFocalLength && (
+              <StyledPhotoMetaItem>
+                <StyledPhotoMetaLabel>
+                  {t('photoMeta.focalLength')}
+                </StyledPhotoMetaLabel>
+                <span>{photoFocalLength}</span>
+              </StyledPhotoMetaItem>
+            )}
+            {photoPanoramicCount && (
+              <StyledPhotoMetaItem>
+                <StyledPhotoMetaLabel>
+                  {t('photoMeta.panoramicCount')}
+                </StyledPhotoMetaLabel>
+                <span>{photoPanoramicCount}</span>
+              </StyledPhotoMetaItem>
+            )}
+          </StyledPhotoMeta>
+        )}
+        {caption && captionPos !== 'top' && (
+          <StyledCaption data-testid="slideshow-caption">
+            {caption}
+          </StyledCaption>
+        )}
+        <StyledSlideshowNav>
+          <StyledSlideshowArrow
+            type="button"
+            onClick={goPrev}
+            disabled={!canGoPrev}
+            aria-label="Previous slide"
+            data-testid="slideshow-prev"
+          >
+            ←
+          </StyledSlideshowArrow>
+          <StyledSlideshowCounter data-testid="slideshow-counter">
+            {currentIndex + 1} / {slides.length}
+          </StyledSlideshowCounter>
+          <StyledSlideshowArrow
+            type="button"
+            onClick={goNext}
+            disabled={!canGoNext}
+            aria-label="Next slide"
+            data-testid="slideshow-next"
+          >
+            →
+          </StyledSlideshowArrow>
+        </StyledSlideshowNav>
+      </StyledSlideshow>
+      {expandable &&
+        expanded &&
+        createPortal(
+          <StyledModalOverlay
+            onClick={() => setExpanded(false)}
+            data-testid="slideshow-image-modal"
+          >
+            <StyledModalContent onClick={(e) => e.stopPropagation()}>
+              <StyledModalClose
+                onClick={() => setExpanded(false)}
+                aria-label="Close"
+              >
+                ×
+              </StyledModalClose>
+              <Image
+                src={current.src}
+                alt={cleanAlt}
+                width={0}
+                height={0}
+                sizes="90vw"
+                style={{
+                  maxWidth: '90vw',
+                  maxHeight: '80vh',
+                  width: 'auto',
+                  height: 'auto',
+                }}
+              />
+              {caption && <StyledCaption>{caption}</StyledCaption>}
+              <StyledModalDownload
+                href={current.src}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open original
+              </StyledModalDownload>
+            </StyledModalContent>
+          </StyledModalOverlay>,
+          document.body,
+        )}
+    </>
+  )
+}

--- a/apps/web/lib/mdx/components.tsx
+++ b/apps/web/lib/mdx/components.tsx
@@ -4,6 +4,7 @@ import { CodeBlock } from '@sdlgr/code-block'
 import { MdxTable } from '@web/components/PostContent/MdxTable'
 import { PostContentEmbed } from '@web/components/PostContent/PostContentEmbed'
 import { PostContentImage } from '@web/components/PostContent/PostContentImage'
+import { PostContentSlideshow } from '@web/components/PostContent/PostContentSlideshow'
 
 export interface MdxComponentLabels {
   copyLabel: string
@@ -14,6 +15,7 @@ export function createMdxComponents(labels: MdxComponentLabels) {
   return {
     Callout,
     Embed: PostContentEmbed,
+    Slideshow: PostContentSlideshow,
     img: PostContentImage,
     h1: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
       <h2 {...props}>{children}</h2>

--- a/apps/web/lib/mdx/remarkEmbeds.spec.ts
+++ b/apps/web/lib/mdx/remarkEmbeds.spec.ts
@@ -644,4 +644,77 @@ describe('remarkEmbeds', () => {
       value: '',
     })
   })
+
+  describe('slideshow blocks', () => {
+    it('transforms slideshow block into Slideshow element with slides JSON', () => {
+      const [result] = runPlugin([
+        {
+          type: 'code',
+          lang: 'slideshow',
+          value:
+            '![alt=A sunset photo](https://example.com/img1.jpg)\n![](https://example.com/img2.jpg)',
+        },
+      ])
+      expect(result.type).toBe('mdxJsxFlowElement')
+      expect(result.name).toBe('Slideshow')
+      expect(result.attributes).toContainEqual({
+        type: 'mdxJsxAttribute',
+        name: 'slides',
+        value: JSON.stringify([
+          { src: 'https://example.com/img1.jpg', alt: 'alt=A sunset photo' },
+          { src: 'https://example.com/img2.jpg', alt: '' },
+        ]),
+      })
+    })
+
+    it('ignores non-image-markdown lines in slideshow block', () => {
+      const [result] = runPlugin([
+        {
+          type: 'code',
+          lang: 'slideshow',
+          value:
+            'this is not an image line\n![](https://example.com/img.jpg)\nanother plain line',
+        },
+      ])
+      expect(result.attributes).toContainEqual({
+        type: 'mdxJsxAttribute',
+        name: 'slides',
+        value: JSON.stringify([
+          { src: 'https://example.com/img.jpg', alt: '' },
+        ]),
+      })
+    })
+
+    it('produces empty slides array when block has no valid image lines', () => {
+      const [result] = runPlugin([
+        {
+          type: 'code',
+          lang: 'slideshow',
+          value: 'no images here\njust plain text',
+        },
+      ])
+      expect(result.attributes).toContainEqual({
+        type: 'mdxJsxAttribute',
+        name: 'slides',
+        value: JSON.stringify([]),
+      })
+    })
+
+    it('passes through non-code nodes unchanged', () => {
+      const node = { type: 'paragraph', value: 'hello' }
+      const [result] = runPlugin([node as CodeNode])
+      expect(result).toEqual(node)
+    })
+
+    it('produces empty slides array when value is undefined', () => {
+      const [result] = runPlugin([
+        { type: 'code', lang: 'slideshow', value: undefined },
+      ])
+      expect(result.attributes).toContainEqual({
+        type: 'mdxJsxAttribute',
+        name: 'slides',
+        value: JSON.stringify([]),
+      })
+    })
+  })
 })

--- a/apps/web/lib/mdx/remarkEmbeds.ts
+++ b/apps/web/lib/mdx/remarkEmbeds.ts
@@ -40,7 +40,32 @@ export function remarkEmbeds() {
         meta?: string | null
         value?: string
       }
-      if (n.type !== 'code' || !EMBED_LANGS.includes(n.lang ?? '')) return node
+      if (n.type !== 'code') return node
+
+      if (n.lang === 'slideshow') {
+        const lines = (n.value ?? '').trim().split('\n').filter(Boolean)
+        const slides = lines
+          .map((line) => {
+            const m = line.match(/^!\[([^\]]*)\]\(([^)]+)\)$/)
+            if (!m) return null
+            return { src: m[2], alt: m[1] }
+          })
+          .filter(Boolean)
+        return {
+          type: 'mdxJsxFlowElement',
+          name: 'Slideshow',
+          attributes: [
+            {
+              type: 'mdxJsxAttribute',
+              name: 'slides',
+              value: JSON.stringify(slides),
+            },
+          ],
+          children: [],
+        }
+      }
+
+      if (!EMBED_LANGS.includes(n.lang ?? '')) return node
 
       const metaFlags = (n.meta ?? '').split(' ').filter(Boolean)
       const showWaypoints = metaFlags.includes('showWaypoints')


### PR DESCRIPTION
## Summary

- New `SlideshowInsertModal` admin component for building multi-image slideshows with per-slide alt text, caption, photo metadata, and reorder/insert-between controls
- New `PostContentSlideshow` viewer with directional CSS keyframe transitions, fixed aspect-ratio container, and prev/next navigation
- Wired slideshow code-fence parsing through `remarkEmbeds`, `components.tsx`, `MarkdownPreview`, and `PostEditor` (insert + edit flows)
- Fixed `parseEmbedBlock` fence-before-image detection order to avoid misidentifying image lines inside slideshow fences
- Deduplicated `ImagePicker` image list to prevent duplicate-key React warnings
- Added `f/9`, `f/10` aperture and `1/320`, `1/400` shutter speed options to both `ImageInsertModal` and `SlideshowInsertModal`
- Increased edit-embed button opacity for better visibility

## Test plan

- [ ] Insert a slideshow block via toolbar button — modal opens, images can be picked per slide
- [ ] Reorder slides with ↑/↓ buttons; insert a new slide between existing ones
- [ ] Edit an existing slideshow block by clicking "Edit slideshow"
- [ ] Preview tab shows slideshow with prev/next navigation and directional transition
- [ ] Published post renders slideshow correctly
- [ ] All existing image insert / edit flows unaffected
- [ ] 200 test suites, 2223 tests — all pass with 100% coverage