### PR TITLE
feat: published live URLs in PostEditor + fix slideshow arrow stability

### DIFF
--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.edit.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.edit.spec.tsx
@@ -74,6 +74,9 @@ jest.mock('@web/i18n/client', () => ({
         'postEditor.draftPreviewLabel': 'Preview:',
         'postEditor.draftPreviewCopy': 'Copy',
         'postEditor.draftPreviewCopied': 'Copied!',
+        'postEditor.publishedUrlLabel': 'Live ({{locale}}):',
+        'postEditor.publishedUrlCopy': 'Copy',
+        'postEditor.publishedUrlCopied': 'Copied!',
         'postEditor.error': 'Something went wrong',
         'images.picker.title': 'Insert Image',
       }
@@ -1075,6 +1078,103 @@ describe('PostEditor', () => {
         expect(
           screen.getByTestId('draft-preview-copy-button'),
         ).toHaveTextContent('Copy')
+      })
+      jest.useRealTimers()
+    })
+  })
+
+  describe('published URL rows', () => {
+    const publishedPost: PostEditorProps['post'] = {
+      post: {
+        ...mockExistingPost.post,
+        status: 'published',
+        previewToken: null,
+      },
+      translations: mockExistingPost.translations,
+    }
+
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: jest.fn().mockResolvedValue(undefined) },
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('shows published URL rows for each translation when published', () => {
+      renderApp(
+        <PostEditor
+          post={publishedPost}
+          categories={mockCategories}
+          users={mockUsers}
+        />,
+      )
+      expect(screen.getByTestId('published-url-row-en')).toBeInTheDocument()
+      expect(screen.getByTestId('published-url-row-es')).toBeInTheDocument()
+      expect(screen.getByTestId('published-url-link-en')).toHaveAttribute(
+        'href',
+        '/en/blog/7/my-post',
+      )
+      expect(screen.getByTestId('published-url-link-es')).toHaveAttribute(
+        'href',
+        '/es/blog/7/mi-post',
+      )
+    })
+
+    it('does not show published URL rows for draft posts', () => {
+      renderApp(
+        <PostEditor
+          post={mockExistingPost}
+          categories={mockCategories}
+          users={mockUsers}
+        />,
+      )
+      expect(
+        screen.queryByTestId('published-url-row-en'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show published URL rows when postNumber is null', () => {
+      renderApp(
+        <PostEditor
+          post={{
+            post: { ...publishedPost.post, postNumber: null },
+            translations: publishedPost.translations,
+          }}
+          categories={mockCategories}
+          users={mockUsers}
+        />,
+      )
+      expect(
+        screen.queryByTestId('published-url-row-en'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('copy button writes URL to clipboard and shows Copied!', async () => {
+      jest.useFakeTimers()
+      renderApp(
+        <PostEditor
+          post={publishedPost}
+          categories={mockCategories}
+          users={mockUsers}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('published-url-copy-en'))
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          expect.stringContaining('/en/blog/7/my-post'),
+        )
+      })
+      await waitFor(() => {
+        expect(screen.getByTestId('published-url-copy-en')).toHaveTextContent(
+          'Copied!',
+        )
+      })
+      jest.runAllTimers()
+      await waitFor(() => {
+        expect(screen.getByTestId('published-url-copy-en')).toHaveTextContent(
+          'Copy',
+        )
       })
       jest.useRealTimers()
     })

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.styles.ts
@@ -494,3 +494,33 @@ export const StyledDraftPreviewCopyButton = styled(Button).attrs({
     opacity: 1;
   }
 `
+
+export const StyledPublishedUrlLink = styled.a`
+  font-size: 0.65rem;
+  color: ${({ theme }) => theme.colors.green};
+  text-decoration: none;
+  opacity: 0.8;
+  font-family: monospace;
+
+  &:hover {
+    opacity: 1;
+    text-decoration: underline;
+  }
+`
+
+export const StyledPublishedUrlCopyButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  font-family: inherit;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.4rem;
+  color: ${({ theme }) => theme.colors.green};
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
+  }
+`

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
@@ -70,6 +70,8 @@ import {
   StyledPreviewTab,
   StyledPreviewTabsBar,
   StyledPublishButton,
+  StyledPublishedUrlCopyButton,
+  StyledPublishedUrlLink,
   StyledSaveButton,
   StyledStatusBadge,
   StyledTextareaWrapper,
@@ -257,6 +259,9 @@ export function PostEditor({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [urlCopied, setUrlCopied] = useState(false)
+  const [copiedPublishedLocale, setCopiedPublishedLocale] = useState<
+    string | null
+  >(null)
   const [isPickerOpen, setIsPickerOpen] = useState(false)
   const [isContentPickerOpen, setIsContentPickerOpen] = useState(false)
   const contentPickerCallbackRef = useRef<
@@ -478,6 +483,26 @@ export function PostEditor({
       })
   }
 
+  const publishedPaths =
+    post && status === 'published' && post.post.postNumber
+      ? post.translations
+          .filter((tr) => tr.slug)
+          .map((tr) => ({
+            locale: tr.locale,
+            path: `/${tr.locale}/blog/${post.post.postNumber}/${tr.slug}`,
+          }))
+      : []
+
+  function handleCopyPublishedUrl(path: string, locale: string) {
+    /* istanbul ignore next */
+    void navigator.clipboard
+      .writeText(window.location.origin + path)
+      .then(() => {
+        setCopiedPublishedLocale(locale)
+        setTimeout(() => setCopiedPublishedLocale(null), 2000)
+      })
+  }
+
   async function handleSave(
     targetStatus: PostStatus = status,
     notify?: boolean,
@@ -558,6 +583,34 @@ export function PostEditor({
               </StyledDraftPreviewCopyButton>
             </StyledDraftPreviewRow>
           )}
+          {publishedPaths.map(({ locale, path }) => (
+            <StyledDraftPreviewRow
+              key={locale}
+              data-testid={`published-url-row-${locale}`}
+            >
+              <StyledDraftPreviewLabel>
+                {t('postEditor.publishedUrlLabel', {
+                  locale: locale.toUpperCase(),
+                })}
+              </StyledDraftPreviewLabel>
+              <StyledPublishedUrlLink
+                href={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid={`published-url-link-${locale}`}
+              >
+                {path}
+              </StyledPublishedUrlLink>
+              <StyledPublishedUrlCopyButton
+                onClick={() => handleCopyPublishedUrl(path, locale)}
+                data-testid={`published-url-copy-${locale}`}
+              >
+                {copiedPublishedLocale === locale
+                  ? t('postEditor.publishedUrlCopied')
+                  : t('postEditor.publishedUrlCopy')}
+              </StyledPublishedUrlCopyButton>
+            </StyledDraftPreviewRow>
+          ))}
         </StyledHeaderLeft>
 
         <StyledActions>

--- a/apps/web/components/PostContent/PostContent.styles.ts
+++ b/apps/web/components/PostContent/PostContent.styles.ts
@@ -260,28 +260,52 @@ export const StyledModalDownload = styled.a`
 export const StyledPhotoMeta = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 1.25rem;
+  gap: 0.35rem 0.75rem;
   justify-content: center;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.5rem;
   margin-top: 0.25rem;
   border-top: 1px solid rgba(251, 251, 251, 0.08);
+
+  ${({ theme }) => theme.media.up.md} {
+    gap: 1.25rem;
+    padding: 0.5rem 0.75rem;
+  }
 `
 
 export const StyledPhotoMetaItem = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 0.15rem;
+  gap: 0.25rem;
   font-family: var(--font-roboto-mono);
-  font-size: 0.75rem;
+  font-size: 0.65rem;
   color: rgba(251, 251, 251, 0.7);
+
+  ${({ theme }) => theme.media.up.md} {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.15rem;
+    font-size: 0.75rem;
+  }
 `
 
 export const StyledPhotoMetaLabel = styled.span`
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   color: rgba(251, 251, 251, 0.4);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+
+  &::after {
+    content: ':';
+  }
+
+  ${({ theme }) => theme.media.up.md} {
+    font-size: 0.6rem;
+
+    &::after {
+      content: '';
+    }
+  }
 `
 
 export const StyledEmbedWrapper = styled.div`

--- a/apps/web/components/PostContent/PostContentSlideshow.spec.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.spec.tsx
@@ -164,7 +164,7 @@ describe('PostContentSlideshow', () => {
     )
   })
 
-  it('shows caption at top when caption-pos=top', () => {
+  it('shows caption below image regardless of caption-pos param', () => {
     renderWithTheme(
       <PostContentSlideshow
         slides={JSON.stringify([

--- a/apps/web/components/PostContent/PostContentSlideshow.spec.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.spec.tsx
@@ -273,6 +273,25 @@ describe('PostContentSlideshow', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('clicking prev/next on expandable slideshow does not open modal', () => {
+    renderWithTheme(
+      <PostContentSlideshow
+        slides={JSON.stringify([
+          { src: '/img1.jpg', alt: 'expand=true&alt=first' },
+          { src: '/img2.jpg', alt: 'expand=true&alt=second' },
+        ])}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('slideshow-next'))
+    expect(
+      screen.queryByTestId('slideshow-image-modal'),
+    ).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('slideshow-prev'))
+    expect(
+      screen.queryByTestId('slideshow-image-modal'),
+    ).not.toBeInTheDocument()
+  })
+
   it('expand=false: clicking image wrapper does not open modal', () => {
     renderWithTheme(<PostContentSlideshow slides={singleSlide} />)
     fireEvent.click(screen.getByTestId('slideshow-image-wrapper'))

--- a/apps/web/components/PostContent/PostContentSlideshow.styles.ts
+++ b/apps/web/components/PostContent/PostContentSlideshow.styles.ts
@@ -65,26 +65,6 @@ export const StyledSlideshowSlide = styled.div<{
   }}
 `
 
-export const StyledSlideshowCaptionOverlay = styled.div<{
-  $pos: 'top' | 'bottom'
-}>`
-  position: absolute;
-  left: 0;
-  right: 0;
-  ${({ $pos }) => ($pos === 'top' ? 'top: 0;' : 'bottom: 0;')}
-  z-index: 3;
-  padding: 0.4rem 0.75rem;
-  background: linear-gradient(
-    ${({ $pos }) => ($pos === 'top' ? 'to bottom' : 'to top')},
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.55) 100%
-  );
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.9);
-  line-height: 1.4;
-  pointer-events: none;
-`
-
 export const StyledSlideshowNav = styled.div`
   display: flex;
   justify-content: center;

--- a/apps/web/components/PostContent/PostContentSlideshow.styles.ts
+++ b/apps/web/components/PostContent/PostContentSlideshow.styles.ts
@@ -1,19 +1,34 @@
 import styled, { css, keyframes } from 'styled-components'
 
-import { Button } from '@sdlgr/button'
-
 export const StyledSlideshow = styled.figure`
   margin: 2rem 0;
   width: 100%;
+`
+
+export const StyledSlideshowImageArea = styled.div`
   position: relative;
+  width: 100%;
+  height: 260px;
+  border-radius: 2px;
+
+  ${({ theme }) => theme.media.up.sm} {
+    height: 360px;
+  }
+
+  ${({ theme }) => theme.media.up.md} {
+    height: 500px;
+  }
+
+  ${({ theme }) => theme.media.up.lg} {
+    height: 640px;
+  }
 `
 
 export const StyledSlideshowImageWrapper = styled.div<{
   $expandable?: boolean
 }>`
-  position: relative;
-  width: 100%;
-  aspect-ratio: 3 / 2;
+  position: absolute;
+  inset: 0;
   background: rgba(0, 0, 0, 0.08);
   border-radius: 2px;
   overflow: hidden;
@@ -50,33 +65,68 @@ export const StyledSlideshowSlide = styled.div<{
   }}
 `
 
+export const StyledSlideshowCaptionOverlay = styled.div<{
+  $pos: 'top' | 'bottom'
+}>`
+  position: absolute;
+  left: 0;
+  right: 0;
+  ${({ $pos }) => ($pos === 'top' ? 'top: 0;' : 'bottom: 0;')}
+  z-index: 3;
+  padding: 0.4rem 0.75rem;
+  background: linear-gradient(
+    ${({ $pos }) => ($pos === 'top' ? 'to bottom' : 'to top')},
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 0.55) 100%
+  );
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.4;
+  pointer-events: none;
+`
+
 export const StyledSlideshowNav = styled.div`
   display: flex;
-  align-items: center;
   justify-content: center;
-  gap: 1rem;
   padding: 0.5rem 0 0.25rem;
 `
 
-export const StyledSlideshowArrow = styled(Button).attrs({ variant: 'text' })`
-  font-size: 1.1rem;
-  line-height: 1;
-  padding: 0.25rem 0.5rem;
+export const StyledSlideshowArrow = styled.button<{ $side: 'prev' | 'next' }>`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: ${({ $side }) => ($side === 'prev' ? '0.5rem' : 'auto')};
+  right: ${({ $side }) => ($side === 'next' ? '0.5rem' : 'auto')};
+  z-index: 2;
+
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  margin: 0;
+
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
   color: ${({ theme }) => theme.colors.white};
-  opacity: 0.6;
+  opacity: 0.75;
 
   &:hover:not(:disabled) {
     opacity: 1;
+    background: rgba(0, 0, 0, 0.65);
     color: ${({ theme }) => theme.colors.green};
   }
 
   &:disabled {
-    opacity: 0.2;
+    opacity: 0.15;
     cursor: not-allowed;
   }
 
-  &::after {
-    display: none;
+  ${({ theme }) => theme.media.up.md} {
+    width: 2.75rem;
+    height: 2.75rem;
   }
 `
 

--- a/apps/web/components/PostContent/PostContentSlideshow.styles.ts
+++ b/apps/web/components/PostContent/PostContentSlideshow.styles.ts
@@ -46,21 +46,40 @@ const slideInFromLeft = keyframes`
   to { transform: translateX(0); }
 `
 
+const slideOutToLeft = keyframes`
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+`
+
+const slideOutToRight = keyframes`
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+`
+
 export const StyledSlideshowSlide = styled.div<{
   $direction: 'next' | 'prev' | 'none'
+  $exiting?: boolean
 }>`
   position: absolute;
   inset: 0;
 
-  ${({ $direction }) => {
+  ${({ $direction, $exiting }) => {
     if ($direction === 'next')
-      return css`
-        animation: ${slideInFromRight} 0.35s ease;
-      `
+      return $exiting
+        ? css`
+            animation: ${slideOutToLeft} 0.35s ease forwards;
+          `
+        : css`
+            animation: ${slideInFromRight} 0.35s ease;
+          `
     if ($direction === 'prev')
-      return css`
-        animation: ${slideInFromLeft} 0.35s ease;
-      `
+      return $exiting
+        ? css`
+            animation: ${slideOutToRight} 0.35s ease forwards;
+          `
+        : css`
+            animation: ${slideInFromLeft} 0.35s ease;
+          `
     return ''
   }}
 `
@@ -81,10 +100,15 @@ export const StyledSlideshowArrow = styled.button<{ $side: 'prev' | 'next' }>`
 
   display: grid;
   place-items: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 1.75rem;
+  height: 1.75rem;
   padding: 0;
   margin: 0;
+
+  svg {
+    width: 7px;
+    height: 12px;
+  }
 
   background: rgba(0, 0, 0, 0.4);
   border: none;
@@ -105,8 +129,13 @@ export const StyledSlideshowArrow = styled.button<{ $side: 'prev' | 'next' }>`
   }
 
   ${({ theme }) => theme.media.up.md} {
-    width: 2.75rem;
-    height: 2.75rem;
+    width: 2.25rem;
+    height: 2.25rem;
+
+    svg {
+      width: 10px;
+      height: 16px;
+    }
   }
 `
 

--- a/apps/web/components/PostContent/PostContentSlideshow.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { useClientTranslation } from '@web/i18n/client'
@@ -39,7 +39,18 @@ export function PostContentSlideshow({
   const [currentIndex, setCurrentIndex] = useState(0)
   const [direction, setDirection] = useState<'next' | 'prev' | 'none'>('none')
   const [expanded, setExpanded] = useState(false)
+  const [exiting, setExiting] = useState<{
+    index: number
+    direction: 'next' | 'prev'
+  } | null>(null)
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { t } = useClientTranslation('common')
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(exitTimerRef.current ?? undefined)
+    }
+  }, [])
 
   let slides: Slide[] = []
   try {
@@ -74,13 +85,25 @@ export function PostContentSlideshow({
   const canGoNext = currentIndex < slides.length - 1
 
   function goPrev() {
+    clearTimeout(exitTimerRef.current ?? undefined)
+    setExiting({ index: currentIndex, direction: 'prev' })
     setDirection('prev')
     setCurrentIndex((i) => i - 1)
+    exitTimerRef.current = setTimeout(
+      /* istanbul ignore next */ () => setExiting(null),
+      350,
+    )
   }
 
   function goNext() {
+    clearTimeout(exitTimerRef.current ?? undefined)
+    setExiting({ index: currentIndex, direction: 'next' })
     setDirection('next')
     setCurrentIndex((i) => i + 1)
+    exitTimerRef.current = setTimeout(
+      /* istanbul ignore next */ () => setExiting(null),
+      350,
+    )
   }
 
   return (
@@ -92,7 +115,26 @@ export function PostContentSlideshow({
             onClick={expandable ? () => setExpanded(true) : undefined}
             data-testid="slideshow-image-wrapper"
           >
-            <StyledSlideshowSlide key={currentIndex} $direction={direction}>
+            {exiting !== null && (
+              <StyledSlideshowSlide
+                key={`exit-${exiting.index}`}
+                $direction={exiting.direction}
+                $exiting
+                aria-hidden="true"
+              >
+                <Image
+                  src={slides[exiting.index].src}
+                  alt=""
+                  fill
+                  sizes="(max-width: 1440px) 100vw, 1440px"
+                  style={{ objectFit: 'contain' }}
+                />
+              </StyledSlideshowSlide>
+            )}
+            <StyledSlideshowSlide
+              key={`enter-${currentIndex}`}
+              $direction={direction}
+            >
               <Image
                 src={current.src}
                 alt={cleanAlt}

--- a/apps/web/components/PostContent/PostContentSlideshow.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.tsx
@@ -19,7 +19,6 @@ import {
 import {
   StyledSlideshow,
   StyledSlideshowArrow,
-  StyledSlideshowCaptionOverlay,
   StyledSlideshowCounter,
   StyledSlideshowImageArea,
   StyledSlideshowImageWrapper,
@@ -56,7 +55,6 @@ export function PostContentSlideshow({
     ? new URLSearchParams(current.alt)
     : null
   const caption = options?.get('caption')
-  const captionPos = options?.get('caption-pos') ?? 'bottom'
   const cleanAlt = options?.get('alt') ?? (options ? '' : (current.alt ?? ''))
   const expandable = options?.get('expand') === 'true'
   const photoIso = options?.get('photo-iso')
@@ -104,14 +102,6 @@ export function PostContentSlideshow({
               />
             </StyledSlideshowSlide>
           </StyledSlideshowImageWrapper>
-          {caption && (
-            <StyledSlideshowCaptionOverlay
-              $pos={captionPos === 'top' ? 'top' : 'bottom'}
-              data-testid="slideshow-caption"
-            >
-              {caption}
-            </StyledSlideshowCaptionOverlay>
-          )}
           <StyledSlideshowArrow
             $side="prev"
             type="button"
@@ -161,6 +151,11 @@ export function PostContentSlideshow({
             </svg>
           </StyledSlideshowArrow>
         </StyledSlideshowImageArea>
+        {caption && (
+          <StyledCaption data-testid="slideshow-caption">
+            {caption}
+          </StyledCaption>
+        )}
         {hasPhotoMeta && (
           <StyledPhotoMeta data-testid="slideshow-photo-meta">
             {photoIso && (

--- a/apps/web/components/PostContent/PostContentSlideshow.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.tsx
@@ -43,12 +43,14 @@ export function PostContentSlideshow({
     index: number
     direction: 'next' | 'prev'
   } | null>(null)
-  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
   const { t } = useClientTranslation('common')
 
   useEffect(() => {
     return () => {
-      clearTimeout(exitTimerRef.current ?? undefined)
+      clearTimeout(exitTimerRef.current)
     }
   }, [])
 
@@ -85,7 +87,7 @@ export function PostContentSlideshow({
   const canGoNext = currentIndex < slides.length - 1
 
   function goPrev() {
-    clearTimeout(exitTimerRef.current ?? undefined)
+    clearTimeout(exitTimerRef.current)
     setExiting({ index: currentIndex, direction: 'prev' })
     setDirection('prev')
     setCurrentIndex((i) => i - 1)
@@ -96,7 +98,7 @@ export function PostContentSlideshow({
   }
 
   function goNext() {
-    clearTimeout(exitTimerRef.current ?? undefined)
+    clearTimeout(exitTimerRef.current)
     setExiting({ index: currentIndex, direction: 'next' })
     setDirection('next')
     setCurrentIndex((i) => i + 1)

--- a/apps/web/components/PostContent/PostContentSlideshow.tsx
+++ b/apps/web/components/PostContent/PostContentSlideshow.tsx
@@ -19,7 +19,9 @@ import {
 import {
   StyledSlideshow,
   StyledSlideshowArrow,
+  StyledSlideshowCaptionOverlay,
   StyledSlideshowCounter,
+  StyledSlideshowImageArea,
   StyledSlideshowImageWrapper,
   StyledSlideshowNav,
   StyledSlideshowSlide,
@@ -86,26 +88,79 @@ export function PostContentSlideshow({
   return (
     <>
       <StyledSlideshow data-testid="post-slideshow">
-        {caption && captionPos === 'top' && (
-          <StyledCaption data-testid="slideshow-caption">
-            {caption}
-          </StyledCaption>
-        )}
-        <StyledSlideshowImageWrapper
-          $expandable={expandable}
-          onClick={expandable ? () => setExpanded(true) : undefined}
-          data-testid="slideshow-image-wrapper"
-        >
-          <StyledSlideshowSlide key={currentIndex} $direction={direction}>
-            <Image
-              src={current.src}
-              alt={cleanAlt}
-              fill
-              sizes="(max-width: 1440px) 100vw, 1440px"
-              style={{ objectFit: 'contain' }}
-            />
-          </StyledSlideshowSlide>
-        </StyledSlideshowImageWrapper>
+        <StyledSlideshowImageArea>
+          <StyledSlideshowImageWrapper
+            $expandable={expandable}
+            onClick={expandable ? () => setExpanded(true) : undefined}
+            data-testid="slideshow-image-wrapper"
+          >
+            <StyledSlideshowSlide key={currentIndex} $direction={direction}>
+              <Image
+                src={current.src}
+                alt={cleanAlt}
+                fill
+                sizes="(max-width: 1440px) 100vw, 1440px"
+                style={{ objectFit: 'contain' }}
+              />
+            </StyledSlideshowSlide>
+          </StyledSlideshowImageWrapper>
+          {caption && (
+            <StyledSlideshowCaptionOverlay
+              $pos={captionPos === 'top' ? 'top' : 'bottom'}
+              data-testid="slideshow-caption"
+            >
+              {caption}
+            </StyledSlideshowCaptionOverlay>
+          )}
+          <StyledSlideshowArrow
+            $side="prev"
+            type="button"
+            onClick={goPrev}
+            disabled={!canGoPrev}
+            aria-label="Previous slide"
+            data-testid="slideshow-prev"
+          >
+            <svg
+              width="10"
+              height="16"
+              viewBox="0 0 10 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M8 2L2 8L8 14"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </StyledSlideshowArrow>
+          <StyledSlideshowArrow
+            $side="next"
+            type="button"
+            onClick={goNext}
+            disabled={!canGoNext}
+            aria-label="Next slide"
+            data-testid="slideshow-next"
+          >
+            <svg
+              width="10"
+              height="16"
+              viewBox="0 0 10 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M2 2L8 8L2 14"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </StyledSlideshowArrow>
+        </StyledSlideshowImageArea>
         {hasPhotoMeta && (
           <StyledPhotoMeta data-testid="slideshow-photo-meta">
             {photoIso && (
@@ -150,33 +205,10 @@ export function PostContentSlideshow({
             )}
           </StyledPhotoMeta>
         )}
-        {caption && captionPos !== 'top' && (
-          <StyledCaption data-testid="slideshow-caption">
-            {caption}
-          </StyledCaption>
-        )}
         <StyledSlideshowNav>
-          <StyledSlideshowArrow
-            type="button"
-            onClick={goPrev}
-            disabled={!canGoPrev}
-            aria-label="Previous slide"
-            data-testid="slideshow-prev"
-          >
-            ←
-          </StyledSlideshowArrow>
           <StyledSlideshowCounter data-testid="slideshow-counter">
             {currentIndex + 1} / {slides.length}
           </StyledSlideshowCounter>
-          <StyledSlideshowArrow
-            type="button"
-            onClick={goNext}
-            disabled={!canGoNext}
-            aria-label="Next slide"
-            data-testid="slideshow-next"
-          >
-            →
-          </StyledSlideshowArrow>
         </StyledSlideshowNav>
       </StyledSlideshow>
       {expandable &&

--- a/apps/web/i18n/locales/en/admin.json
+++ b/apps/web/i18n/locales/en/admin.json
@@ -149,6 +149,9 @@
     "draftPreviewLabel": "Preview:",
     "draftPreviewCopy": "Copy",
     "draftPreviewCopied": "Copied!",
+    "publishedUrlLabel": "Live ({{locale}}):",
+    "publishedUrlCopy": "Copy",
+    "publishedUrlCopied": "Copied!",
     "error": "Something went wrong, please try again"
   },
   "images": {


### PR DESCRIPTION
## Summary

- **Published URL rows**: When a post is published, show per-locale live URLs (e.g. `/en/blog/7/my-post`) in the PostEditor header below the draft preview row. Each URL is a clickable link (opens in new tab) with a copy button that shows "Copied!" feedback.
- **Slideshow arrow stability**: Arrows were jumping vertically when switching between slides with/without captions, because a caption above the image area shifted the container position. Fixed by rendering captions as overlays inside the image area (gradient-backed text at top/bottom edge) so the container height is always fixed and arrows always center at 50%.
- **Slideshow height increase**: Increased fixed heights from 220/260/380/480px to 260/360/500/640px to match the previous aspect-ratio layout more closely on larger screens.

## Test plan

- [ ] Edit a published post — verify "Live (EN):" and "Live (ES):" rows appear with correct URLs
- [ ] Click copy button — verify URL is copied and button shows "Copied!" briefly
- [ ] Edit a draft post — verify no live URL rows appear
- [ ] Slideshow with mixed captions/no-captions: switch between slides and verify arrows stay in the same vertical position
- [ ] Verify captions render as overlays on the image edge
- [ ] Run `yarn test:web` — 200 suites, 2228 tests, all pass