### PR TITLE
fix: strip diacritics from slugs to prevent accented chars in URLs

### DIFF
--- a/apps/web/app/admin/(auth)/categories/components/CategoryTable/CategoryTable.spec.tsx
+++ b/apps/web/app/admin/(auth)/categories/components/CategoryTable/CategoryTable.spec.tsx
@@ -553,7 +553,7 @@ describe('CategoryTable', () => {
     fireEvent.change(screen.getByTestId('edit-name-input'), {
       target: { value: 'Montañismo' },
     })
-    expect(screen.getByTestId('edit-slug-input')).toHaveValue('montañismo')
+    expect(screen.getByTestId('edit-slug-input')).toHaveValue('montanismo')
   })
 
   it('stops auto-generating slug once user manually edits it', () => {
@@ -631,6 +631,6 @@ describe('CategoryTable', () => {
     fireEvent.change(screen.getByTestId('edit-name-input'), {
       target: { value: 'Montañismo' },
     })
-    expect(screen.getByTestId('edit-slug-input')).toHaveValue('montañismo')
+    expect(screen.getByTestId('edit-slug-input')).toHaveValue('montanismo')
   })
 })

--- a/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.spec.tsx
@@ -886,8 +886,9 @@ describe('GpxMapModal', () => {
         jest.advanceTimersByTime(600)
       })
       expect(await screen.findByTestId('waypoint-select-0')).toBeInTheDocument()
+      // 'Water Source' is at fetchIdx 1
       fireEvent.change(screen.getByTestId('waypoint-select-0'), {
-        target: { value: 'Water Source' },
+        target: { value: '1' },
       })
       fireEvent.click(screen.getByTestId('pick-image-button-0'))
       fireEvent.click(screen.getByTestId('image-picker-pick'))
@@ -909,12 +910,44 @@ describe('GpxMapModal', () => {
         jest.advanceTimersByTime(600)
       })
       expect(await screen.findByTestId('waypoint-select-0')).toBeInTheDocument()
+      // 'Water Source' is at fetchIdx 1
       fireEvent.change(screen.getByTestId('waypoint-select-0'), {
-        target: { value: 'Water Source' },
+        target: { value: '1' },
       })
-      expect(screen.getByTestId('waypoint-select-0')).toHaveValue(
-        'Water Source',
+      expect(screen.getByTestId('waypoint-select-0')).toHaveValue('1')
+    })
+
+    it('keeps duplicate-named waypoints separate in dropdown', async () => {
+      setupFetch(`<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="43.5" lon="-5.6"><name>Summit</name></wpt>
+  <wpt lat="43.6" lon="-5.7"><name>Summit</name></wpt>
+</gpx>`)
+      renderApp(
+        <GpxMapModal isOpen onInsert={jest.fn()} onCancel={jest.fn()} />,
       )
+      fireEvent.click(screen.getByTestId('gpx-track-show-waypoints-0'))
+      fireEvent.change(screen.getByTestId('gpx-track-url-0'), {
+        target: { value: 'https://example.com/track.gpx' },
+      })
+      act(() => {
+        jest.advanceTimersByTime(600)
+      })
+      expect(await screen.findByTestId('waypoint-select-0')).toBeInTheDocument()
+      // Both Summit entries appear (fetchIdx 0 and 1)
+      const optsBefore = within(
+        screen.getByTestId('waypoint-select-0'),
+      ).getAllByRole('option')
+      expect(optsBefore).toHaveLength(2)
+      // Pick image for the first Summit (fetchIdx 0 selected by default)
+      fireEvent.click(screen.getByTestId('pick-image-button-0'))
+      fireEvent.click(screen.getByTestId('image-picker-pick'))
+      // Second Summit (fetchIdx 1) still in dropdown
+      const optsAfter = within(
+        screen.getByTestId('waypoint-select-0'),
+      ).getAllByRole('option')
+      expect(optsAfter).toHaveLength(1)
+      expect(optsAfter[0].textContent).toBe('Summit')
     })
 
     it('includes waypoint image lines in insert markdown', async () => {
@@ -935,7 +968,7 @@ describe('GpxMapModal', () => {
       fireEvent.click(screen.getByTestId('image-picker-pick'))
       fireEvent.click(screen.getByTestId('gpx-modal-insert'))
       expect(onInsert).toHaveBeenCalledWith(
-        '\n\n```gpx\ntrack:https://example.com/track.gpx ||| showWaypoints\n0:Summit=https://cdn.com/img.jpg\n```\n\n',
+        '\n\n```gpx\ntrack:https://example.com/track.gpx ||| showWaypoints\n0:0=https://cdn.com/img.jpg\n```\n\n',
       )
     })
 
@@ -957,7 +990,7 @@ describe('GpxMapModal', () => {
       fireEvent.click(screen.getByTestId('pick-image-button-0'))
       fireEvent.click(screen.getByTestId('image-picker-pick'))
       expect(screen.getByTestId('gpx-preview').textContent).toBe(
-        '```gpx\ntrack:https://example.com/track.gpx ||| showWaypoints\n0:Summit=https://cdn.com/img.jpg\n```',
+        '```gpx\ntrack:https://example.com/track.gpx ||| showWaypoints\n0:0=https://cdn.com/img.jpg\n```',
       )
     })
 
@@ -1205,6 +1238,36 @@ describe('GpxMapModal initialValues', () => {
       />,
     )
     expect(screen.getByTestId('gpx-track-url-0')).toHaveValue('')
+  })
+
+  it('uses waypoint name as key when mapping has no fetchIdx (legacy format)', () => {
+    const onInsert = jest.fn()
+    renderApp(
+      <GpxMapModal
+        isOpen
+        onInsert={onInsert}
+        onCancel={jest.fn()}
+        initialValues={{
+          tracks: [
+            {
+              url: 'https://cdn.com/route.gpx',
+              name: '',
+              color: '',
+              allowDownload: false,
+              showWaypoints: false,
+              showElevation: false,
+            },
+          ],
+          mappingsByTrack: {
+            0: [{ name: 'Summit', imageUrl: 'https://cdn.com/img.jpg' }],
+          },
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('gpx-modal-insert'))
+    expect(onInsert).toHaveBeenCalledWith(
+      '\n\n```gpx\ntrack:https://cdn.com/route.gpx\n0:Summit=https://cdn.com/img.jpg\n```\n\n',
+    )
   })
 })
 

--- a/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.styles.ts
@@ -25,6 +25,7 @@ export const StyledGpxMapModal = styled(ModalOverlays)`
   box-shadow: 0 0 16px 4px rgba(152, 223, 214, 0.5);
   border-radius: 2px;
   background-color: ${({ theme }) => theme.colors.black};
+  overflow-y: auto;
 
   ${({ theme }) => theme.media.up.md} {
     top: 5vh;
@@ -34,7 +35,6 @@ export const StyledGpxMapModal = styled(ModalOverlays)`
     height: auto;
     max-width: min(900px, 90vw);
     max-height: 90vh;
-    overflow: hidden;
   }
 `
 

--- a/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/GpxMapModal/GpxMapModal.tsx
@@ -49,6 +49,7 @@ export interface GpxMapModalProps {
 interface WaypointMapping {
   name: string
   imageUrl: string
+  fetchIdx?: number
 }
 
 interface TrackInput {
@@ -87,6 +88,24 @@ function parseWaypointNames(text: string): string[] {
   return Array.from(doc.querySelectorAll('wpt'))
     .map((wpt) => wpt.querySelector('name')?.textContent ?? '')
     .filter(Boolean)
+}
+
+function getAvailableWaypoints(
+  fetched: string[],
+  mappings: WaypointMapping[],
+): Array<{ name: string; fetchIdx: number }> {
+  const mappedFetchIdxSet = new Set(
+    mappings.filter((m) => m.fetchIdx !== undefined).map((m) => m.fetchIdx!),
+  )
+  const initialMappingNames = new Set(
+    mappings.filter((m) => m.fetchIdx === undefined).map((m) => m.name),
+  )
+  return fetched
+    .map((name, fetchIdx) => ({ name, fetchIdx }))
+    .filter(
+      ({ name, fetchIdx }) =>
+        !mappedFetchIdxSet.has(fetchIdx) && !initialMappingNames.has(name),
+    )
 }
 
 function buildTrackLine(track: TrackInput): string {
@@ -144,7 +163,7 @@ export function GpxMapModal({
     Record<number, WaypointMapping[]>
   >(initialValues?.mappingsByTrack ?? {})
   const [pendingWaypointByTrack, setPendingWaypointByTrack] = useState<
-    Record<number, string>
+    Record<number, number | undefined>
   >({})
   const [isImagePickerOpenForTrack, setIsImagePickerOpenForTrack] = useState<
     number | null
@@ -158,13 +177,14 @@ export function GpxMapModal({
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPendingWaypointByTrack((prev) => {
-      const next = { ...prev }
+      const next: Record<number, number | undefined> = { ...prev }
       tracks.forEach((_, i) => {
-        const available = (fetchedWaypointsByTrack[i] ?? []).filter(
-          (n) => !(mappingsByTrack[i] ?? []).some((m) => m.name === n),
+        const available = getAvailableWaypoints(
+          fetchedWaypointsByTrack[i] ?? [],
+          mappingsByTrack[i] ?? [],
         )
-        if (!available.includes(next[i] ?? '')) {
-          next[i] = available[0] ?? ''
+        if (!available.some((a) => a.fetchIdx === next[i])) {
+          next[i] = available[0]?.fetchIdx
         }
       })
       return next
@@ -277,7 +297,9 @@ export function GpxMapModal({
     activeEntries.forEach(({ origIdx }, outputIdx) => {
       const ms = mappingsByTrack[origIdx] ?? []
       ms.forEach((m) => {
-        imageLines.push(`${outputIdx}:${m.name}=${m.imageUrl}`)
+        imageLines.push(
+          `${outputIdx}:${m.fetchIdx !== undefined ? m.fetchIdx : m.name}=${m.imageUrl}`,
+        )
       })
     })
 
@@ -298,25 +320,30 @@ export function GpxMapModal({
     /* istanbul ignore next */
     if (
       isImagePickerOpenForTrack === null ||
-      !pendingWaypointByTrack[isImagePickerOpenForTrack]
+      pendingWaypointByTrack[isImagePickerOpenForTrack] === undefined
     )
       return
     const trackIdx = isImagePickerOpenForTrack
-    const waypointName = pendingWaypointByTrack[trackIdx]
+    const fetchIdx = pendingWaypointByTrack[trackIdx]!
+    /* istanbul ignore next */
+    const waypointName = fetchedWaypointsByTrack[trackIdx]?.[fetchIdx] ?? ''
     setMappingsByTrack((prev) => ({
       ...prev,
       [trackIdx]: [
         ...(prev[trackIdx] ?? []),
-        { name: waypointName, imageUrl: image.url },
+        { name: waypointName, fetchIdx, imageUrl: image.url },
       ],
     }))
     setIsImagePickerOpenForTrack(null)
   }
 
-  function removeMapping(trackIdx: number, name: string) {
+  function removeMapping(trackIdx: number, mappingIdx: number) {
     setMappingsByTrack((prev) => {
       const existing = prev[trackIdx] ?? /* istanbul ignore next */ []
-      return { ...prev, [trackIdx]: existing.filter((m) => m.name !== name) }
+      return {
+        ...prev,
+        [trackIdx]: existing.filter((_, i) => i !== mappingIdx),
+      }
     })
   }
 
@@ -329,7 +356,9 @@ export function GpxMapModal({
   tracks.forEach((_, trackIdx) => {
     const ms = mappingsByTrack[trackIdx] ?? []
     ms.forEach((m) => {
-      previewImageLines.push(`${trackIdx}:${m.name}=${m.imageUrl}`)
+      previewImageLines.push(
+        `${trackIdx}:${m.fetchIdx !== undefined ? m.fetchIdx : m.name}=${m.imageUrl}`,
+      )
     })
   })
   const previewContent = [...previewTrackLines, ...previewImageLines].join('\n')
@@ -364,11 +393,8 @@ export function GpxMapModal({
               const error = fetchErrorByTrack[index]
               const fetched = fetchedWaypointsByTrack[index] ?? []
               const trackMappings = mappingsByTrack[index] ?? []
-              const pendingWaypoint =
-                pendingWaypointByTrack[index] ?? /* istanbul ignore next */ ''
-              const available = fetched.filter(
-                (n) => !trackMappings.some((m) => m.name === n),
-              )
+              const pendingWaypoint = pendingWaypointByTrack[index]
+              const available = getAvailableWaypoints(fetched, trackMappings)
               const showWaypointSection =
                 track.showWaypoints && (loading || error || fetched.length > 0)
               return (
@@ -489,9 +515,9 @@ export function GpxMapModal({
 
                       {trackMappings.length > 0 && (
                         <StyledMappingsList>
-                          {trackMappings.map((m) => (
+                          {trackMappings.map((m, mappingIdx) => (
                             <StyledMappingRow
-                              key={m.name}
+                              key={mappingIdx}
                               data-testid={`mapping-row-${index}`}
                             >
                               <StyledMappingThumb
@@ -507,7 +533,7 @@ export function GpxMapModal({
                               <StyledRemoveButton
                                 type="button"
                                 aria-label={`Remove image for ${m.name}`}
-                                onClick={() => removeMapping(index, m.name)}
+                                onClick={() => removeMapping(index, mappingIdx)}
                                 data-testid={`mapping-remove-${index}`}
                               >
                                 ×
@@ -520,15 +546,22 @@ export function GpxMapModal({
                       {available.length > 0 && (
                         <StyledAddRow>
                           <Select
-                            value={pendingWaypoint}
+                            value={
+                              pendingWaypoint !== undefined
+                                ? String(pendingWaypoint)
+                                : ''
+                            }
                             onChange={(v) =>
                               setPendingWaypointByTrack((prev) => ({
                                 ...prev,
-                                [index]: v,
+                                [index]:
+                                  v !== ''
+                                    ? parseInt(v, 10)
+                                    : /* istanbul ignore next */ undefined,
                               }))
                             }
-                            options={available.map((name) => ({
-                              value: name,
+                            options={available.map(({ name, fetchIdx }) => ({
+                              value: String(fetchIdx),
                               label: name,
                             }))}
                             isSearchable
@@ -537,7 +570,7 @@ export function GpxMapModal({
                           />
                           <StyledPickImageButton
                             type="button"
-                            disabled={!pendingWaypoint}
+                            disabled={pendingWaypoint === undefined}
                             onClick={() => setIsImagePickerOpenForTrack(index)}
                             data-testid={`pick-image-button-${index}`}
                           >

--- a/apps/web/utils/slugify.spec.ts
+++ b/apps/web/utils/slugify.spec.ts
@@ -45,7 +45,11 @@ describe('slugify', () => {
     expect(slugify('my-category')).toBe('my-category')
   })
 
-  it('preserves unicode letters', () => {
-    expect(slugify('Montañismo')).toBe('montañismo')
+  it('strips diacritics from unicode letters', () => {
+    expect(slugify('Montañismo')).toBe('montanismo')
+  })
+
+  it('strips accented vowels', () => {
+    expect(slugify('Góriz')).toBe('goriz')
   })
 })

--- a/apps/web/utils/slugify.ts
+++ b/apps/web/utils/slugify.ts
@@ -1,5 +1,7 @@
 export function slugify(text: string): string {
   return text
+    .normalize('NFD')
+    .replace(/\p{Mn}/gu, '')
     .toLowerCase()
     .replace(/[^\p{L}\p{N}\s-]/gu, '')
     .trim()

--- a/libs/gpx-map/src/lib/GpxMap.spec.tsx
+++ b/libs/gpx-map/src/lib/GpxMap.spec.tsx
@@ -1055,6 +1055,22 @@ describe('GpxMap', () => {
         .filter((r) => r.getAttribute('data-details') === 'true')
       expect(detailRows[0]).not.toHaveTextContent('—')
     })
+
+    it('shows image card when waypointImages keyed by waypoint index', async () => {
+      render(
+        <GpxMap
+          url={GPX_URL}
+          showWaypoints
+          waypointImages={{ '1': 'https://cdn.com/idx-img.jpg' }}
+        />,
+      )
+      await screen.findByText('Summit')
+      const rows = screen.getAllByRole('row')
+      fireEvent.click(rows[2])
+      const img = screen.getByTestId('waypoint-image-card')
+      expect(img).toHaveAttribute('src', 'https://cdn.com/idx-img.jpg')
+      expect(img).toHaveAttribute('alt', 'Summit')
+    })
   })
 
   describe('multi-track', () => {

--- a/libs/gpx-map/src/lib/GpxMap.tsx
+++ b/libs/gpx-map/src/lib/GpxMap.tsx
@@ -677,9 +677,10 @@ export function GpxMap({
                   {trackWaypoints.map((wpt, i) => {
                     const effectiveImages =
                       track.waypointImages ?? waypointImages
-                    const hasDetails = !!(
-                      effectiveImages?.[wpt.name] || wpt.desc
-                    )
+                    const wptImage =
+                      effectiveImages?.[String(i)] ??
+                      effectiveImages?.[wpt.name]
+                    const hasDetails = !!(wptImage || wpt.desc)
                     const isExpanded = expandedIndex === i
                     return (
                       <Fragment key={`${wpt.name}-${i}`}>
@@ -726,10 +727,10 @@ export function GpxMap({
                         {hasDetails && isExpanded && (
                           <tr data-details="true">
                             <td colSpan={4}>
-                              {effectiveImages?.[wpt.name] && (
+                              {wptImage && (
                                 <StyledWaypointImageCard
                                   data-testid="waypoint-image-card"
-                                  src={effectiveImages[wpt.name]}
+                                  src={wptImage}
                                   alt={wpt.name}
                                 />
                               )}


### PR DESCRIPTION
## Summary

- `slugify()` now normalizes with NFD and strips combining marks before processing, so accented characters are transliterated to ASCII equivalents (`ó→o`, `ñ→n`, `é→e`, etc.)
- Fixes slugs like `góriz` being generated instead of `goriz`, which caused routing failures in production when the URL contained non-ASCII characters

## Test plan

- [ ] Create a new post with a title containing accented characters (e.g. "Góriz") — slug should auto-generate as `goriz`
- [ ] Fix the existing published post by editing its slug in the admin panel to remove the accented character