### PR TITLE
feat: skip post notifications on localhost and verify pages before sending

### DIFF
--- a/apps/web/lib/email/notifyPostPublished.spec.ts
+++ b/apps/web/lib/email/notifyPostPublished.spec.ts
@@ -4,6 +4,8 @@
 const mockGetPostTranslations = jest.fn()
 const mockSendNewPostNotifications = jest.fn()
 const mockLoggerError = jest.fn()
+const mockLoggerWarn = jest.fn()
+const mockGetSiteUrl = jest.fn()
 
 jest.mock('@web/lib/db/queries/posts', () => ({
   getPostTranslations: mockGetPostTranslations,
@@ -12,7 +14,10 @@ jest.mock('@web/lib/email/sendNewPostNotifications', () => ({
   sendNewPostNotifications: mockSendNewPostNotifications,
 }))
 jest.mock('@web/lib/logger', () => ({
-  logger: { error: mockLoggerError },
+  logger: { error: mockLoggerError, warn: mockLoggerWarn },
+}))
+jest.mock('@web/utils/url/generateUrl', () => ({
+  getSiteUrl: mockGetSiteUrl,
 }))
 
 const { notifyPostPublished } = require('./notifyPostPublished') as {
@@ -43,6 +48,8 @@ const mockPost = {
 describe('notifyPostPublished', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGetSiteUrl.mockReturnValue('https://sawl.dev')
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 })
     mockGetPostTranslations.mockResolvedValue([])
     mockSendNewPostNotifications.mockResolvedValue(undefined)
   })
@@ -116,5 +123,127 @@ describe('notifyPostPublished', () => {
     expect(mockSendNewPostNotifications).toHaveBeenCalledWith(
       expect.objectContaining({ translations: {} }),
     )
+  })
+
+  describe('localhost guard', () => {
+    it('skips notifications and warns when site URL is localhost', async () => {
+      mockGetSiteUrl.mockReturnValue('http://localhost:4200')
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockSendNewPostNotifications).not.toHaveBeenCalled()
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ logContext: 'test-context' }),
+        expect.stringContaining('localhost'),
+      )
+    })
+
+    it('does not call getPostTranslations on localhost', async () => {
+      mockGetSiteUrl.mockReturnValue('http://localhost:3000')
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockGetPostTranslations).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('page reachability check', () => {
+    it('fetches en page URL with HEAD before sending', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'en', title: 'My Post', slug: 'my-post', excerpt: 'Excerpt' },
+      ])
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://sawl.dev/en/blog/5/my-post',
+        { method: 'HEAD' },
+      )
+    })
+
+    it('fetches es page URL with HEAD before sending', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'es', title: 'Mi Post', slug: 'mi-post', excerpt: 'Resumen' },
+      ])
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://sawl.dev/es/blog/5/mi-post',
+        { method: 'HEAD' },
+      )
+    })
+
+    it('sends notifications when both en and es pages return 200', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'en', title: 'My Post', slug: 'my-post', excerpt: 'Excerpt' },
+        { locale: 'es', title: 'Mi Post', slug: 'mi-post', excerpt: 'Resumen' },
+      ])
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockSendNewPostNotifications).toHaveBeenCalled()
+    })
+
+    it('skips notifications when en page returns non-200', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'en', title: 'My Post', slug: 'my-post', excerpt: 'Excerpt' },
+        { locale: 'es', title: 'Mi Post', slug: 'mi-post', excerpt: 'Resumen' },
+      ])
+      global.fetch = jest
+        .fn()
+        .mockImplementation((url: string) =>
+          Promise.resolve(
+            url.includes('/en/')
+              ? { ok: false, status: 404 }
+              : { ok: true, status: 200 },
+          ),
+        ) as jest.Mock
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockSendNewPostNotifications).not.toHaveBeenCalled()
+    })
+
+    it('skips notifications when es page returns non-200', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'en', title: 'My Post', slug: 'my-post', excerpt: 'Excerpt' },
+        { locale: 'es', title: 'Mi Post', slug: 'mi-post', excerpt: 'Resumen' },
+      ])
+      global.fetch = jest
+        .fn()
+        .mockImplementation((url: string) =>
+          Promise.resolve(
+            url.includes('/es/')
+              ? { ok: false, status: 500 }
+              : { ok: true, status: 200 },
+          ),
+        ) as jest.Mock
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockSendNewPostNotifications).not.toHaveBeenCalled()
+    })
+
+    it('warns with URL and status when a page is not reachable', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'en', title: 'My Post', slug: 'my-post', excerpt: 'Excerpt' },
+      ])
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ ok: false, status: 404 }) as jest.Mock
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://sawl.dev/en/blog/5/my-post',
+          status: 404,
+          logContext: 'test-context',
+        }),
+        expect.stringContaining('not reachable'),
+      )
+    })
+
+    it('logs error and skips notifications when fetch throws', async () => {
+      mockGetPostTranslations.mockResolvedValue([
+        { locale: 'en', title: 'My Post', slug: 'my-post', excerpt: 'Excerpt' },
+      ])
+      const fetchErr = new Error('Network error')
+      global.fetch = jest.fn().mockRejectedValue(fetchErr) as jest.Mock
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(mockLoggerError).toHaveBeenCalledWith(fetchErr, 'test-context')
+      expect(mockSendNewPostNotifications).not.toHaveBeenCalled()
+    })
+
+    it('does not call fetch when translations are empty', async () => {
+      mockGetPostTranslations.mockResolvedValue([])
+      await notifyPostPublished(mockPost, 'test-context')
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/web/lib/email/notifyPostPublished.ts
+++ b/apps/web/lib/email/notifyPostPublished.ts
@@ -1,6 +1,7 @@
 import { getPostTranslations } from '@web/lib/db/queries/posts'
 import { sendNewPostNotifications } from '@web/lib/email/sendNewPostNotifications'
 import { logger } from '@web/lib/logger'
+import { getSiteUrl } from '@web/utils/url/generateUrl'
 
 interface PostForNotification {
   id: string
@@ -12,15 +13,26 @@ interface PostForNotification {
   seriesOrder: number | null
 }
 
+type TranslationEntry = { title: string; excerpt: string; slug: string }
+
 export async function notifyPostPublished(
   post: PostForNotification,
   logContext: string,
 ): Promise<void> {
   try {
+    const siteUrl = getSiteUrl()
+
+    if (siteUrl.includes('localhost')) {
+      logger.warn(
+        { logContext },
+        'notifyPostPublished: skipping notifications on localhost',
+      )
+      return
+    }
+
     const allTranslations = await getPostTranslations(post.id)
-    const translationsByLocale: Partial<
-      Record<'en' | 'es', { title: string; excerpt: string; slug: string }>
-    > = {}
+    const translationsByLocale: Partial<Record<'en' | 'es', TranslationEntry>> =
+      {}
     for (const t of allTranslations) {
       translationsByLocale[t.locale as 'en' | 'es'] = {
         title: t.title,
@@ -28,6 +40,21 @@ export async function notifyPostPublished(
         excerpt: t.excerpt,
       }
     }
+
+    for (const [locale, translation] of Object.entries(
+      translationsByLocale,
+    ) as [string, TranslationEntry][]) {
+      const url = `${siteUrl}/${locale}/blog/${post.postNumber}/${translation.slug}`
+      const res = await fetch(url, { method: 'HEAD' })
+      if (!res.ok) {
+        logger.warn(
+          { url, status: res.status, logContext },
+          'notifyPostPublished: post page not reachable, skipping notifications',
+        )
+        return
+      }
+    }
+
     await sendNewPostNotifications({
       postId: post.id,
       postNumber: post.postNumber,


### PR DESCRIPTION
## Summary

- **Localhost guard**: `notifyPostPublished` now checks `getSiteUrl()` at the start — if it contains `localhost`, logs a warning and returns without sending any emails. No more accidental subscriber notifications during local dev.
- **Page reachability check**: Before calling `sendNewPostNotifications`, a HEAD request is made to every translated post URL (`/en/blog/…` and `/es/blog/…`). If either returns a non-200 response, notifications are skipped and the failure is logged with the URL and status code.

## Test plan

- [ ] Publish a post locally — no emails should be sent, warning logged
- [ ] Publish a post in production with both `/en` and `/es` pages returning 200 — emails sent normally
- [ ] Publish a post where the en or es slug is broken (e.g. causes 404) — emails skipped, warning logged with URL + status