### PR TITLE
feat: improve slideshow arrows and gpx waypoint tooltips

### DIFF
--- a/apps/web/components/PostContent/PostContentSlideshow.styles.ts
+++ b/apps/web/components/PostContent/PostContentSlideshow.styles.ts
@@ -108,23 +108,25 @@ export const StyledSlideshowArrow = styled.button<{ $side: 'prev' | 'next' }>`
   svg {
     width: 7px;
     height: 12px;
+    translate: ${({ $side }) => ($side === 'next' ? '1px 0' : '-1px 0')};
   }
 
-  background: rgba(0, 0, 0, 0.4);
-  border: none;
+  background: rgba(0, 0, 0, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.6);
   border-radius: 50%;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
   cursor: pointer;
   color: ${({ theme }) => theme.colors.white};
-  opacity: 0.75;
+  opacity: 1;
 
   &:hover:not(:disabled) {
-    opacity: 1;
-    background: rgba(0, 0, 0, 0.65);
+    background: rgba(0, 0, 0, 0.8);
+    border-color: ${({ theme }) => theme.colors.green};
     color: ${({ theme }) => theme.colors.green};
   }
 
   &:disabled {
-    opacity: 0.15;
+    opacity: 0.2;
     cursor: not-allowed;
   }
 
@@ -135,6 +137,7 @@ export const StyledSlideshowArrow = styled.button<{ $side: 'prev' | 'next' }>`
     svg {
       width: 10px;
       height: 16px;
+      translate: ${({ $side }) => ($side === 'next' ? '1px 0' : '-1px 0')};
     }
   }
 `

--- a/libs/gpx-map/src/lib/GpxMap.spec.tsx
+++ b/libs/gpx-map/src/lib/GpxMap.spec.tsx
@@ -948,10 +948,16 @@ describe('GpxMap', () => {
       expect(mockEachLayer).not.toHaveBeenCalled()
     })
 
-    it('binds popup to layer with matching title', () => {
-      const mockBindPopup = jest.fn()
+    const makeWptMarker = (title: string) => ({
+      options: { title, type: 'waypoint' },
+      unbindPopup: jest.fn().mockReturnThis(),
+      bindTooltip: jest.fn(),
+    })
+
+    it('unbinds popup and binds tooltip for waypoint with matching title', () => {
+      const marker = makeWptMarker('Refugio Mar')
       mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
-        cb({ options: { title: 'Refugio Mar' }, bindPopup: mockBindPopup })
+        cb(marker)
       })
       render(
         <GpxMap
@@ -965,25 +971,50 @@ describe('GpxMap', () => {
       act(() => {
         loadedCallback()
       })
-      expect(mockBindPopup).toHaveBeenCalledWith(
+      expect(marker.unbindPopup).toHaveBeenCalled()
+      expect(marker.bindTooltip).toHaveBeenCalledWith(
         expect.stringContaining('https://cdn.com/img.jpg'),
-        expect.objectContaining({ maxWidth: 210 }),
+        expect.objectContaining({ className: 'gpx-waypoint-popup' }),
       )
-      expect(mockBindPopup).toHaveBeenCalledWith(
-        expect.stringContaining('Refugio Mar'),
+    })
+
+    it('uses index-based key from waypointImages for tooltip', () => {
+      const marker = makeWptMarker('Brecha de Roland')
+      mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
+        cb(marker)
+      })
+      render(
+        <GpxMap
+          url={GPX_URL}
+          waypointImages={{ '0': 'https://cdn.com/idx.jpg' }}
+        />,
+      )
+      const loadedCallback = mockOn.mock.calls.find(
+        (c: [string, () => void]) => c[0] === 'loaded',
+      )?.[1]
+      act(() => {
+        loadedCallback()
+      })
+      expect(marker.bindTooltip).toHaveBeenCalledWith(
+        expect.stringContaining('https://cdn.com/idx.jpg'),
         expect.anything(),
       )
     })
 
-    it('does not bind popup to layer without title', () => {
-      const mockBindPopup = jest.fn()
+    it('supports duplicate waypoint names via index-based lookup', () => {
+      const m0 = makeWptMarker('Summit')
+      const m1 = makeWptMarker('Summit')
       mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
-        cb({ options: {}, bindPopup: mockBindPopup })
+        cb(m0)
+        cb(m1)
       })
       render(
         <GpxMap
           url={GPX_URL}
-          waypointImages={{ 'Refugio Mar': 'https://cdn.com/img.jpg' }}
+          waypointImages={{
+            '0': 'https://cdn.com/img0.jpg',
+            '1': 'https://cdn.com/img1.jpg',
+          }}
         />,
       )
       const loadedCallback = mockOn.mock.calls.find(
@@ -992,13 +1023,23 @@ describe('GpxMap', () => {
       act(() => {
         loadedCallback()
       })
-      expect(mockBindPopup).not.toHaveBeenCalled()
+      expect(m0.bindTooltip).toHaveBeenCalledWith(
+        expect.stringContaining('https://cdn.com/img0.jpg'),
+        expect.anything(),
+      )
+      expect(m1.bindTooltip).toHaveBeenCalledWith(
+        expect.stringContaining('https://cdn.com/img1.jpg'),
+        expect.anything(),
+      )
     })
 
-    it('does not bind popup when title not in waypointImages', () => {
-      const mockBindPopup = jest.fn()
+    it('recursively iterates nested FeatureGroup to find markers', () => {
+      const marker = makeWptMarker('Refugio Mar')
+      const innerGroup = {
+        eachLayer: jest.fn((cb: (l: unknown) => void) => cb(marker)),
+      }
       mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
-        cb({ options: { title: 'Unknown' }, bindPopup: mockBindPopup })
+        cb(innerGroup)
       })
       render(
         <GpxMap
@@ -1012,13 +1053,115 @@ describe('GpxMap', () => {
       act(() => {
         loadedCallback()
       })
-      expect(mockBindPopup).not.toHaveBeenCalled()
+      expect(marker.bindTooltip).toHaveBeenCalledWith(
+        expect.stringContaining('https://cdn.com/img.jpg'),
+        expect.objectContaining({ className: 'gpx-waypoint-popup' }),
+      )
+    })
+
+    it('skips unnamed waypoint when no index image exists', () => {
+      const marker = {
+        options: { type: 'waypoint' },
+        unbindPopup: jest.fn().mockReturnThis(),
+        bindTooltip: jest.fn(),
+      }
+      mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
+        cb(marker)
+      })
+      render(
+        <GpxMap
+          url={GPX_URL}
+          waypointImages={{ 'Refugio Mar': 'https://cdn.com/img.jpg' }}
+        />,
+      )
+      const loadedCallback = mockOn.mock.calls.find(
+        (c: [string, () => void]) => c[0] === 'loaded',
+      )?.[1]
+      act(() => {
+        loadedCallback()
+      })
+      expect(marker.unbindPopup).not.toHaveBeenCalled()
+      expect(marker.bindTooltip).not.toHaveBeenCalled()
+    })
+
+    it('skips non-waypoint layers (start/end markers)', () => {
+      const startMarker = {
+        options: {},
+        unbindPopup: jest.fn(),
+        bindTooltip: jest.fn(),
+      }
+      mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
+        cb(startMarker)
+      })
+      render(
+        <GpxMap
+          url={GPX_URL}
+          waypointImages={{ '0': 'https://cdn.com/img.jpg' }}
+        />,
+      )
+      const loadedCallback = mockOn.mock.calls.find(
+        (c: [string, () => void]) => c[0] === 'loaded',
+      )?.[1]
+      act(() => {
+        loadedCallback()
+      })
+      expect(startMarker.unbindPopup).not.toHaveBeenCalled()
+      expect(startMarker.bindTooltip).not.toHaveBeenCalled()
+    })
+
+    it('does not bind tooltip when waypoint not in waypointImages', () => {
+      const marker = makeWptMarker('Unknown')
+      mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
+        cb(marker)
+      })
+      render(
+        <GpxMap
+          url={GPX_URL}
+          waypointImages={{ 'Refugio Mar': 'https://cdn.com/img.jpg' }}
+        />,
+      )
+      const loadedCallback = mockOn.mock.calls.find(
+        (c: [string, () => void]) => c[0] === 'loaded',
+      )?.[1]
+      act(() => {
+        loadedCallback()
+      })
+      expect(marker.unbindPopup).not.toHaveBeenCalled()
+      expect(marker.bindTooltip).not.toHaveBeenCalled()
+    })
+
+    it('binds tooltip for waypoint with no title when index image exists', () => {
+      const marker = {
+        options: { type: 'waypoint' },
+        unbindPopup: jest.fn().mockReturnThis(),
+        bindTooltip: jest.fn(),
+      }
+      mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
+        cb(marker)
+      })
+      render(
+        <GpxMap
+          url={GPX_URL}
+          waypointImages={{ '0': 'https://cdn.com/notitle.jpg' }}
+        />,
+      )
+      const loadedCallback = mockOn.mock.calls.find(
+        (c: [string, () => void]) => c[0] === 'loaded',
+      )?.[1]
+      act(() => {
+        loadedCallback()
+      })
+      expect(marker.unbindPopup).toHaveBeenCalled()
+      expect(marker.bindTooltip).toHaveBeenCalledWith(
+        expect.stringContaining('https://cdn.com/notitle.jpg'),
+        expect.objectContaining({ className: 'gpx-waypoint-popup' }),
+      )
     })
 
     it('uses per-track waypointImages when provided on track def', () => {
-      const mockBindPopup = jest.fn()
+      const marker = makeWptMarker('Summit')
       mockEachLayer.mockImplementationOnce((cb: (l: unknown) => void) => {
-        cb({ options: { title: 'Summit' }, bindPopup: mockBindPopup })
+        cb(marker)
       })
       render(
         <GpxMap
@@ -1036,7 +1179,7 @@ describe('GpxMap', () => {
       act(() => {
         loadedCallback()
       })
-      expect(mockBindPopup).toHaveBeenCalledWith(
+      expect(marker.bindTooltip).toHaveBeenCalledWith(
         expect.stringContaining('https://cdn.com/track-img.jpg'),
         expect.anything(),
       )

--- a/libs/gpx-map/src/lib/GpxMap.spec.tsx
+++ b/libs/gpx-map/src/lib/GpxMap.spec.tsx
@@ -967,7 +967,11 @@ describe('GpxMap', () => {
       })
       expect(mockBindPopup).toHaveBeenCalledWith(
         expect.stringContaining('https://cdn.com/img.jpg'),
-        expect.objectContaining({ maxWidth: 200 }),
+        expect.objectContaining({ maxWidth: 210 }),
+      )
+      expect(mockBindPopup).toHaveBeenCalledWith(
+        expect.stringContaining('Refugio Mar'),
+        expect.anything(),
       )
     })
 

--- a/libs/gpx-map/src/lib/GpxMap.styles.ts
+++ b/libs/gpx-map/src/lib/GpxMap.styles.ts
@@ -18,6 +18,47 @@ export const StyledMapContainer = styled.div`
     height: 100%;
     border-radius: 2px;
   }
+
+  .gpx-waypoint-popup .leaflet-popup-content-wrapper {
+    background: #111;
+    color: #eee;
+    border-radius: 8px;
+    padding: 0;
+    overflow: hidden;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+  }
+
+  .gpx-waypoint-popup .leaflet-popup-content {
+    margin: 0;
+  }
+
+  .gpx-waypoint-popup .leaflet-popup-tip {
+    background: #111;
+  }
+
+  .gpx-waypoint-popup .leaflet-popup-close-button {
+    color: rgba(255, 255, 255, 0.5);
+    top: 4px;
+    right: 6px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .gpx-waypoint-popup.leaflet-tooltip {
+    background: #111;
+    color: #eee;
+    border: none;
+    border-radius: 8px;
+    padding: 0;
+    overflow: hidden;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+
+    &::before {
+      border-top-color: #111;
+    }
+  }
 `
 
 export const StyledDownloadBar = styled.div`

--- a/libs/gpx-map/src/lib/GpxMap.tsx
+++ b/libs/gpx-map/src/lib/GpxMap.tsx
@@ -387,8 +387,11 @@ function GpxTrackLayer({
           const imgUrl = name ? imgs[name] : undefined
           if (imgUrl) {
             ;(l as L.Marker).bindPopup(
-              `<img src="${imgUrl}" style="width:180px;max-height:160px;object-fit:contain;display:block;" alt="${name}" />`,
-              { maxWidth: 200 },
+              `<div style="background:#111;border-radius:6px;overflow:hidden;min-width:160px;max-width:200px;">` +
+                `<img src="${imgUrl}" style="width:100%;max-height:150px;object-fit:cover;display:block;" alt="${name}" />` +
+                `<p style="margin:0;padding:6px 8px;font-size:0.75rem;color:#eee;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${name}</p>` +
+                `</div>`,
+              { maxWidth: 210, className: 'gpx-waypoint-popup' },
             )
           }
         })

--- a/libs/gpx-map/src/lib/GpxMap.tsx
+++ b/libs/gpx-map/src/lib/GpxMap.tsx
@@ -379,22 +379,34 @@ function GpxTrackLayer({
       map.fitBounds(layer.getBounds())
       const imgs = waypointImagesRef.current
       if (imgs) {
-        layer.eachLayer((l) => {
+        let wptIdx = 0
+        const bindToMarker = (l: L.Layer) => {
+          if ((l as L.LayerGroup).eachLayer) {
+            ;(l as L.LayerGroup).eachLayer(bindToMarker)
+            return
+          }
           const opts = (l as L.Marker).options as L.MarkerOptions & {
             title?: string
+            type?: string
           }
-          const name = opts?.title
-          const imgUrl = name ? imgs[name] : undefined
+          if (opts.type !== 'waypoint') return
+          const name = opts.title
+          const imgUrl = imgs[String(wptIdx)] ?? (name ? imgs[name] : undefined)
+          wptIdx++
           if (imgUrl) {
-            ;(l as L.Marker).bindPopup(
-              `<div style="background:#111;border-radius:6px;overflow:hidden;min-width:160px;max-width:200px;">` +
-                `<img src="${imgUrl}" style="width:100%;max-height:150px;object-fit:cover;display:block;" alt="${name}" />` +
-                `<p style="margin:0;padding:6px 8px;font-size:0.75rem;color:#eee;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${name}</p>` +
-                `</div>`,
-              { maxWidth: 210, className: 'gpx-waypoint-popup' },
-            )
+            const content =
+              `<div style="min-width:160px;max-width:200px;">` +
+              `<img src="${imgUrl}" style="width:100%;max-height:150px;object-fit:cover;display:block;" alt="${name ?? ''}" />` +
+              `<p style="margin:0;padding:6px 8px;font-size:0.75rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${name ?? ''}</p>` +
+              `</div>`
+            ;(l as L.Marker).unbindPopup().bindTooltip(content, {
+              className: 'gpx-waypoint-popup',
+              direction: 'top',
+              offset: [0, -20],
+            })
           }
-        })
+        }
+        layer.eachLayer(bindToMarker)
       }
     })
 


### PR DESCRIPTION
## Summary

- Slideshow arrows: darker background (`rgba(0,0,0,0.72)`), white border ring, optical centering nudge per side, green hover accent
- GPX waypoint tooltips: dark card styling (bg `#111`) with thumbnail image and name label
- GPX tooltip lookup: recursive `eachLayer` traversal to handle `leaflet-gpx`'s `FeatureGroup` wrapping; index-based key lookup (`"0"`, `"1"`, …) with name fallback; filter by `type='waypoint'` to skip start/end markers
- Disabled click popups (`unbindPopup`) — hover-only tooltips via `bindTooltip`

## Test plan

- [ ] 100% coverage on `gpx-map` (139 tests pass)
- [ ] Waypoint tooltip shows correct image for each waypoint, including duplicates with same name
- [ ] Slideshow arrows visible and centered on both mobile and desktop