### PR TITLE
feat: interactive canyoning croquis generator + post embed

### DIFF
--- a/apps/web-e2e/src/e2e/admin-cards.cy.ts
+++ b/apps/web-e2e/src/e2e/admin-cards.cy.ts
@@ -22,6 +22,17 @@ describe('Admin cards — canyon waypoints generator', () => {
     })
   }
 
+  const openCroquis = (attempt = 0) => {
+    cy.get('[data-testid="card-type-croquis"]').click()
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500)
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-testid="cg-text"]').length === 0 && attempt < 8) {
+        openCroquis(attempt + 1)
+      }
+    })
+  }
+
   it('renders a preview from the canyon waypoints tab', () => {
     cy.visit('/admin/cards')
     cy.get('[data-testid="card-generator"]', { timeout: 15000 }).should(

--- a/apps/web/app/admin/(auth)/cards/components/CardGenerator/CardGenerator.spec.tsx
+++ b/apps/web/app/admin/(auth)/cards/components/CardGenerator/CardGenerator.spec.tsx
@@ -136,6 +136,10 @@ jest.mock('../CanyonWaypointsGenerator', () => ({
   ),
 }))
 
+jest.mock('../CroquisGenerator', () => ({
+  CroquisGenerator: () => <div data-testid="croquis-generator-mock" />,
+}))
+
 describe('CardGenerator', () => {
   it('renders the title', () => {
     renderApp(<CardGenerator />)
@@ -148,6 +152,7 @@ describe('CardGenerator', () => {
     expect(screen.getByTestId('card-type-summary-route')).toBeInTheDocument()
     expect(screen.getByTestId('card-type-summary-ferrata')).toBeInTheDocument()
     expect(screen.getByTestId('card-type-canyon-waypoints')).toBeInTheDocument()
+    expect(screen.getByTestId('card-type-croquis')).toBeInTheDocument()
   })
 
   it('renders the RouteForm by default', () => {
@@ -314,6 +319,21 @@ describe('CardGenerator', () => {
     expect(
       screen.getByTestId('canyon-waypoints-generator-mock'),
     ).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('card-type-canyoning-data'))
+    expect(screen.getByTestId('canyoning-form-mock')).toBeInTheDocument()
+  })
+
+  it('shows the croquis generator on the croquis tab', () => {
+    renderApp(<CardGenerator />)
+    fireEvent.click(screen.getByTestId('card-type-croquis'))
+    expect(screen.getByTestId('croquis-generator-mock')).toBeInTheDocument()
+    expect(screen.queryByTestId('route-form-mock')).not.toBeInTheDocument()
+  })
+
+  it('returns to a spec form after leaving the croquis tab', () => {
+    renderApp(<CardGenerator />)
+    fireEvent.click(screen.getByTestId('card-type-croquis'))
+    expect(screen.getByTestId('croquis-generator-mock')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('card-type-canyoning-data'))
     expect(screen.getByTestId('canyoning-form-mock')).toBeInTheDocument()
   })

--- a/apps/web/app/admin/(auth)/cards/components/CardGenerator/CardGenerator.tsx
+++ b/apps/web/app/admin/(auth)/cards/components/CardGenerator/CardGenerator.tsx
@@ -16,6 +16,7 @@ import type {
 import { CanyonWaypointsGenerator } from '../CanyonWaypointsGenerator'
 import { CanyoningForm } from '../CanyoningForm'
 import { CardPreview } from '../CardPreview'
+import { CroquisGenerator } from '../CroquisGenerator'
 import { FerrataForm } from '../FerrataForm'
 import { RouteForm } from '../RouteForm'
 import { WaypointForm } from '../WaypointForm'
@@ -30,12 +31,18 @@ import {
 } from './CardGenerator.styles'
 
 type CardKind = CardSpec['kind']
-type Tab = CardKind | 'waypoints' | 'waypoint-single' | 'canyon-waypoints'
+type Tab =
+  | CardKind
+  | 'waypoints'
+  | 'waypoint-single'
+  | 'canyon-waypoints'
+  | 'croquis'
 
 const TABS: Array<{ kind: Tab; labelKey: string }> = [
   { kind: 'summary-route', labelKey: 'cards.tabs.route' },
   { kind: 'canyoning-data', labelKey: 'cards.tabs.canyonData' },
   { kind: 'canyon-waypoints', labelKey: 'cards.tabs.canyonWaypoints' },
+  { kind: 'croquis', labelKey: 'cards.tabs.croquis' },
   { kind: 'summary-ferrata', labelKey: 'cards.tabs.ferrata' },
   { kind: 'waypoints', labelKey: 'cards.tabs.waypointsGpx' },
   { kind: 'waypoint-single', labelKey: 'cards.tabs.waypointSingle' },
@@ -45,6 +52,7 @@ const NON_SPEC_TABS: Tab[] = [
   'waypoints',
   'waypoint-single',
   'canyon-waypoints',
+  'croquis',
 ]
 
 const DEFAULT_CANYONING: CanyoningCardData = {
@@ -135,6 +143,8 @@ export function CardGenerator() {
         <WaypointForm />
       ) : activeKind === 'canyon-waypoints' ? (
         <CanyonWaypointsGenerator />
+      ) : activeKind === 'croquis' ? (
+        <CroquisGenerator />
       ) : (
         <StyledLayout>
           <StyledPanelForm>

--- a/apps/web/app/admin/(auth)/cards/components/Croquis/Croquis.spec.tsx
+++ b/apps/web/app/admin/(auth)/cards/components/Croquis/Croquis.spec.tsx
@@ -1,0 +1,216 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import axios, { AxiosError } from 'axios'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+import type { CroquisObstacle } from '@web/lib/cards'
+
+import { Croquis } from './Croquis'
+
+function makeAxiosError(status: number, data: unknown): AxiosError {
+  return new AxiosError('error', String(status), undefined, undefined, {
+    status,
+    data,
+    statusText: 'Error',
+    headers: {},
+    config: {} as never,
+  })
+}
+
+jest.mock('@web/i18n/client', () => {
+  const admin: Record<string, unknown> = jest.requireActual(
+    '@web/i18n/locales/en/admin.json',
+  )
+  return {
+    useClientTranslation: () => ({
+      t: (key: string): string => {
+        const val = key
+          .split('.')
+          .reduce<unknown>(
+            (o, k) =>
+              typeof o === 'object' && o !== null
+                ? (o as Record<string, unknown>)[k]
+                : undefined,
+            admin,
+          )
+        return typeof val === 'string' ? val : key
+      },
+    }),
+  }
+})
+
+jest.mock('@web/components/Croquis', () => ({
+  CroquisMap: () => <div data-testid="croquis-map-mock" />,
+}))
+
+function ob(overrides: Partial<CroquisObstacle> = {}): CroquisObstacle {
+  return {
+    type: 'salto',
+    title: 'Jump one',
+    meters: 5,
+    side: null,
+    severity: 'easy',
+    notes: [],
+    ...overrides,
+  }
+}
+
+const SuccessImage = class {
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+  set src(_: string) {
+    setTimeout(() => this.onload?.(), 0)
+  }
+} as unknown as typeof Image
+
+const mockGetContext = jest.fn(() => ({
+  scale: jest.fn(),
+  drawImage: jest.fn(),
+}))
+const mockToBlob = jest.fn()
+const mockCreateObjectURL = jest.fn(() => 'blob:mock-url')
+const mockRevokeObjectURL = jest.fn()
+
+beforeAll(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    value: mockGetContext,
+    writable: true,
+  })
+  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+    value: mockToBlob,
+    writable: true,
+  })
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  global.URL.createObjectURL = mockCreateObjectURL
+  global.URL.revokeObjectURL = mockRevokeObjectURL
+  mockToBlob.mockImplementation((cb: (b: Blob) => void) =>
+    cb(new Blob(['png'], { type: 'image/png' })),
+  )
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('Croquis (admin preview)', () => {
+  it('renders the interactive map and the export bar', () => {
+    renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+    expect(screen.getByTestId('croquis-map-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-download')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-upload')).toBeInTheDocument()
+  })
+
+  describe('PNG export', () => {
+    it('downloads on click', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      renderApp(<Croquis obstacles={[ob()]} lang="en" filename="my-croquis" />)
+      fireEvent.click(screen.getByTestId('croquis-download'))
+      await waitFor(() => expect(mockToBlob).toHaveBeenCalled())
+      global.Image = origImage
+    })
+
+    it('shows an error when the canvas is unavailable', async () => {
+      mockGetContext.mockReturnValueOnce(null)
+      const origImage = global.Image
+      global.Image = SuccessImage
+      renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+      fireEvent.click(screen.getByTestId('croquis-download'))
+      expect(
+        await screen.findByTestId('croquis-export-error'),
+      ).toBeInTheDocument()
+      global.Image = origImage
+    })
+  })
+
+  describe('upload', () => {
+    it('uploads and shows the link', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      const postSpy = jest
+        .spyOn(axios, 'post')
+        .mockResolvedValue({ data: { url: 'https://x/y.png' } })
+      renderApp(<Croquis obstacles={[ob()]} lang="en" filename="c" />)
+      fireEvent.click(screen.getByTestId('croquis-upload'))
+      expect(await screen.findByTestId('croquis-upload-link')).toHaveAttribute(
+        'href',
+        'https://x/y.png',
+      )
+      expect(postSpy).toHaveBeenCalledWith('/api/upload', expect.any(FormData))
+      global.Image = origImage
+    })
+
+    it('shows the server error on failure', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      jest
+        .spyOn(axios, 'post')
+        .mockRejectedValue(makeAxiosError(500, { error: 'Upload failed' }))
+      renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+      fireEvent.click(screen.getByTestId('croquis-upload'))
+      expect(
+        await screen.findByTestId('croquis-upload-error'),
+      ).toHaveTextContent('Upload failed')
+      global.Image = origImage
+    })
+
+    it('falls back to a generic error when the axios error has no message', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      jest.spyOn(axios, 'post').mockRejectedValue(makeAxiosError(500, {}))
+      renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+      fireEvent.click(screen.getByTestId('croquis-upload'))
+      expect(
+        await screen.findByTestId('croquis-upload-error'),
+      ).toHaveTextContent('Upload failed')
+      global.Image = origImage
+    })
+
+    it('shows a fallback error when the response has no url', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      jest.spyOn(axios, 'post').mockResolvedValue({ data: {} })
+      renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+      fireEvent.click(screen.getByTestId('croquis-upload'))
+      expect(
+        await screen.findByTestId('croquis-upload-error'),
+      ).toBeInTheDocument()
+      global.Image = origImage
+    })
+
+    it('shows an error on a non-axios failure', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      jest.spyOn(axios, 'post').mockRejectedValue(new Error('boom'))
+      renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+      fireEvent.click(screen.getByTestId('croquis-upload'))
+      expect(
+        await screen.findByTestId('croquis-upload-error'),
+      ).toBeInTheDocument()
+      global.Image = origImage
+    })
+
+    it('shows a loading label while uploading', async () => {
+      const origImage = global.Image
+      global.Image = SuccessImage
+      let resolve!: (v: unknown) => void
+      jest.spyOn(axios, 'post').mockReturnValue(
+        new Promise((r) => {
+          resolve = r
+        }),
+      )
+      renderApp(<Croquis obstacles={[ob()]} lang="en" />)
+      const button = screen.getByTestId('croquis-upload')
+      fireEvent.click(button)
+      await waitFor(() => expect(button).toHaveTextContent('Uploading…'))
+      resolve({ data: { url: 'https://x/y.png' } })
+      await waitFor(() =>
+        expect(button).toHaveTextContent('Upload to Cloudinary'),
+      )
+      global.Image = origImage
+    })
+  })
+})

--- a/apps/web/app/admin/(auth)/cards/components/Croquis/Croquis.styles.ts
+++ b/apps/web/app/admin/(auth)/cards/components/Croquis/Croquis.styles.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+
+export const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  /* The preview column is a flex row that stretches its children; opt out so the
+     croquis keeps its natural (aspect-ratio) height instead of being squashed. */
+  align-self: flex-start;
+`
+
+export const StyledActionBar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`
+
+export const StyledError = styled.p`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.orange};
+  margin: 0;
+`
+
+export const StyledUploadedLink = styled.a`
+  font-size: 0.8125rem;
+  color: ${({ theme }) => theme.colors.green};
+`

--- a/apps/web/app/admin/(auth)/cards/components/Croquis/Croquis.tsx
+++ b/apps/web/app/admin/(auth)/cards/components/Croquis/Croquis.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import axios, { isAxiosError } from 'axios'
+import { useCallback, useMemo, useState } from 'react'
+
+import { Button } from '@sdlgr/button'
+
+import { CroquisMap } from '@web/components/Croquis'
+import { useClientTranslation } from '@web/i18n/client'
+import { croquisCard, svgToPng } from '@web/lib/cards'
+import type { CroquisObstacle, Lang } from '@web/lib/cards'
+
+import {
+  StyledActionBar,
+  StyledError,
+  StyledUploadedLink,
+  StyledWrapper,
+} from './Croquis.styles'
+
+interface CroquisProps {
+  obstacles: CroquisObstacle[]
+  lang: Lang
+  /** Base name (no extension) for the PNG download and Cloudinary upload. */
+  filename?: string
+}
+
+/**
+ * Admin croquis preview: the interactive map plus a PNG export / Cloudinary
+ * upload bar. The map itself is the shared, read-only CroquisMap.
+ */
+export function Croquis({
+  obstacles,
+  lang,
+  filename = 'croquis',
+}: CroquisProps) {
+  const { t } = useClientTranslation('admin')
+
+  const [exportError, setExportError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null)
+
+  const staticSvg = useMemo(
+    () => croquisCard(obstacles, lang),
+    [obstacles, lang],
+  )
+
+  const exportPng = useCallback(
+    () => svgToPng(staticSvg.svg, staticSvg.width, staticSvg.height),
+    [staticSvg],
+  )
+
+  async function handleDownload() {
+    setExportError(null)
+    try {
+      const blob = await exportPng()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${filename}.png`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      setExportError(t('cards.errors.pngExport'))
+    }
+  }
+
+  async function handleUpload() {
+    setUploadError(null)
+    setUploadedUrl(null)
+    setUploading(true)
+    try {
+      const blob = await exportPng()
+      const formData = new FormData()
+      formData.append(
+        'file',
+        new File([blob], `${filename}.png`, { type: 'image/png' }),
+      )
+      formData.append('name', filename)
+      formData.append('altText', filename)
+      const res = await axios.post<{ url?: string }>('/api/upload', formData)
+      if (!res.data.url) {
+        setUploadError(t('cards.errors.upload'))
+        return
+      }
+      setUploadedUrl(res.data.url)
+    } catch (err) {
+      setUploadError(
+        isAxiosError(err)
+          ? (err.response?.data?.error ?? t('cards.errors.upload'))
+          : t('cards.errors.upload'),
+      )
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <StyledWrapper data-testid="croquis">
+      <CroquisMap obstacles={obstacles} lang={lang} />
+
+      <StyledActionBar>
+        <Button
+          type="button"
+          variant="contained"
+          colorScheme="success"
+          size="sm"
+          onClick={() => void handleDownload()}
+          data-testid="croquis-download"
+        >
+          {t('cards.actions.download')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          colorScheme="success"
+          size="sm"
+          onClick={() => void handleUpload()}
+          disabled={uploading}
+          data-testid="croquis-upload"
+        >
+          {uploading ? t('cards.actions.uploading') : t('cards.actions.upload')}
+        </Button>
+        {uploadedUrl && (
+          <StyledUploadedLink
+            href={uploadedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="croquis-upload-link"
+          >
+            {t('cards.actions.uploaded')}
+          </StyledUploadedLink>
+        )}
+      </StyledActionBar>
+
+      {exportError && (
+        <StyledError data-testid="croquis-export-error">
+          {exportError}
+        </StyledError>
+      )}
+      {uploadError && (
+        <StyledError data-testid="croquis-upload-error">
+          {uploadError}
+        </StyledError>
+      )}
+    </StyledWrapper>
+  )
+}

--- a/apps/web/app/admin/(auth)/cards/components/Croquis/index.ts
+++ b/apps/web/app/admin/(auth)/cards/components/Croquis/index.ts
@@ -1,0 +1,1 @@
+export { Croquis } from './Croquis'

--- a/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/CroquisGenerator.spec.tsx
+++ b/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/CroquisGenerator.spec.tsx
@@ -1,0 +1,215 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import axios, { AxiosError } from 'axios'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+import { CroquisGenerator } from './CroquisGenerator'
+
+function makeAxiosError(status: number, data: unknown): AxiosError {
+  return new AxiosError('error', String(status), undefined, undefined, {
+    status,
+    data,
+    statusText: 'Error',
+    headers: {},
+    config: {} as never,
+  })
+}
+
+jest.mock('@web/i18n/client', () => {
+  const admin: Record<string, unknown> = jest.requireActual(
+    '@web/i18n/locales/en/admin.json',
+  )
+  return {
+    useClientTranslation: () => ({
+      t: (key: string): string => {
+        const val = key
+          .split('.')
+          .reduce<unknown>(
+            (o, k) =>
+              typeof o === 'object' && o !== null
+                ? (o as Record<string, unknown>)[k]
+                : undefined,
+            admin,
+          )
+        return typeof val === 'string' ? val : key
+      },
+    }),
+  }
+})
+
+jest.mock('../Croquis', () => ({
+  Croquis: ({
+    obstacles,
+    lang,
+    filename,
+  }: {
+    obstacles: unknown[]
+    lang: string
+    filename: string
+  }) => (
+    <div data-testid="croquis-mock">
+      <span data-testid="c-count">{obstacles.length}</span>
+      <span data-testid="c-lang">{lang}</span>
+      <span data-testid="c-filename">{filename}</span>
+    </div>
+  ),
+}))
+
+const JUMP_TEXT = 'salto: Jump 2m - 42.6092 0.1412'
+
+describe('CroquisGenerator', () => {
+  it('shows the empty hint until there are obstacles', () => {
+    renderApp(<CroquisGenerator />)
+    expect(screen.getByTestId('cg-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('croquis-mock')).not.toBeInTheDocument()
+  })
+
+  it('draws the croquis once the text has drawable obstacles', () => {
+    renderApp(<CroquisGenerator />)
+    fireEvent.change(screen.getByTestId('cg-text'), {
+      target: { value: JUMP_TEXT },
+    })
+    expect(screen.getByTestId('croquis-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('c-count')).toHaveTextContent('1')
+    expect(screen.queryByTestId('cg-empty')).not.toBeInTheDocument()
+  })
+
+  it('ignores waypoints that are not drawable', () => {
+    renderApp(<CroquisGenerator />)
+    fireEvent.change(screen.getByTestId('cg-text'), {
+      target: { value: 'info: Nice view - 42.6 0.14' },
+    })
+    expect(screen.getByTestId('cg-empty')).toBeInTheDocument()
+  })
+
+  it('names the file from the prefix and language', () => {
+    renderApp(<CroquisGenerator />)
+    fireEvent.change(screen.getByTestId('cg-text'), {
+      target: { value: JUMP_TEXT },
+    })
+    fireEvent.change(screen.getByTestId('cg-name'), {
+      target: { value: 'Mascún' },
+    })
+    expect(screen.getByTestId('c-filename')).toHaveTextContent(
+      'croquis-mascun-en',
+    )
+  })
+
+  it('switches the language', () => {
+    renderApp(<CroquisGenerator />)
+    fireEvent.change(screen.getByTestId('cg-text'), {
+      target: { value: JUMP_TEXT },
+    })
+    fireEvent.click(screen.getByTestId('cg-lang-es'))
+    expect(screen.getByTestId('c-lang')).toHaveTextContent('es')
+    expect(screen.getByTestId('c-filename')).toHaveTextContent(
+      'croquis-croquis-es',
+    )
+  })
+
+  it('disables Parse until a url is entered', () => {
+    renderApp(<CroquisGenerator />)
+    expect(screen.getByTestId('cg-import')).toBeDisabled()
+    fireEvent.change(screen.getByTestId('cg-gpx'), {
+      target: { value: 'https://x/y.gpx' },
+    })
+    expect(screen.getByTestId('cg-import')).not.toBeDisabled()
+  })
+
+  describe('GPX import', () => {
+    function enterUrl() {
+      fireEvent.change(screen.getByTestId('cg-gpx'), {
+        target: { value: 'https://x/y.gpx' },
+      })
+    }
+
+    it('fills the textarea from parsed waypoints', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({
+        data: { data: [{ categories: ['salto'], title: 'Jump', notes: [] }] },
+      })
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      await screen.findByTestId('croquis-mock')
+      expect(screen.getByTestId('c-count')).toHaveTextContent('1')
+    })
+
+    it('errors when the response has no data', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({ data: {} })
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      expect(await screen.findByTestId('cg-error')).toHaveTextContent(
+        'Could not parse GPX file',
+      )
+    })
+
+    it('errors when no waypoints are found', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({ data: { data: [] } })
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      expect(await screen.findByTestId('cg-error')).toHaveTextContent(
+        'No waypoints found',
+      )
+    })
+
+    it('shows the server error message', async () => {
+      jest
+        .spyOn(axios, 'get')
+        .mockRejectedValue(makeAxiosError(400, { error: 'Bad GPX' }))
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      expect(await screen.findByTestId('cg-error')).toHaveTextContent('Bad GPX')
+    })
+
+    it('falls back to a generic error when the axios error has no message', async () => {
+      jest.spyOn(axios, 'get').mockRejectedValue(makeAxiosError(500, {}))
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      expect(await screen.findByTestId('cg-error')).toHaveTextContent(
+        'Could not parse GPX file',
+      )
+    })
+
+    it('falls back to a generic error for non-axios failures', async () => {
+      jest.spyOn(axios, 'get').mockRejectedValue(new Error('boom'))
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      expect(await screen.findByTestId('cg-error')).toHaveTextContent(
+        'Could not parse GPX file',
+      )
+    })
+
+    it('shows a parsing label while loading', async () => {
+      let resolve!: (v: unknown) => void
+      jest.spyOn(axios, 'get').mockReturnValue(
+        new Promise((r) => {
+          resolve = r
+        }),
+      )
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      const button = screen.getByTestId('cg-import')
+      fireEvent.click(button)
+      await waitFor(() => expect(button).toHaveTextContent('Parsing…'))
+      resolve({ data: { data: [] } })
+      await waitFor(() => expect(button).toHaveTextContent('Parse'))
+    })
+
+    it('clears a previous error when the url changes', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({ data: {} })
+      renderApp(<CroquisGenerator />)
+      enterUrl()
+      fireEvent.click(screen.getByTestId('cg-import'))
+      await screen.findByTestId('cg-error')
+      fireEvent.change(screen.getByTestId('cg-gpx'), {
+        target: { value: 'https://x/z.gpx' },
+      })
+      expect(screen.queryByTestId('cg-error')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/CroquisGenerator.styles.ts
+++ b/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/CroquisGenerator.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const StyledEmpty = styled.p`
+  font-size: 0.8125rem;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: 0.4;
+  margin: 0;
+`

--- a/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/CroquisGenerator.tsx
+++ b/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/CroquisGenerator.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import axios, { isAxiosError } from 'axios'
+import { useMemo, useState } from 'react'
+
+import { Button } from '@sdlgr/button'
+import { FieldGroup, FieldHelper, FieldLabel, Input } from '@sdlgr/input'
+
+import { useClientTranslation } from '@web/i18n/client'
+import {
+  parseCanyonWaypointsText,
+  serializeCanyonWaypoints,
+  toCroquisObstacles,
+  waypointSlug,
+} from '@web/lib/cards'
+import type { CanyonWaypoint, Lang } from '@web/lib/cards'
+
+import {
+  StyledError,
+  StyledForm,
+  StyledGpxRow,
+  StyledLangToggle,
+  StyledSection,
+  StyledSectionTitle,
+  StyledTextarea,
+} from '../CanyonWaypointsGenerator/CanyonWaypointsGenerator.styles'
+import {
+  StyledLayout,
+  StyledPanelForm,
+  StyledPanelPreview,
+} from '../CardGenerator/CardGenerator.styles'
+import { Croquis } from '../Croquis'
+import { StyledEmpty } from './CroquisGenerator.styles'
+
+const LANGS: Lang[] = ['en', 'es']
+
+/**
+ * Builds an interactive canyon croquis (river schematic) from the same waypoint
+ * text as the waypoint-card generator. Only jump / rappel / slide obstacles are
+ * drawn; the result can be explored on hover and exported to a PNG.
+ */
+export function CroquisGenerator() {
+  const { t } = useClientTranslation('admin')
+  const [lang, setLang] = useState<Lang>('en')
+  const [name, setName] = useState('')
+  const [text, setText] = useState('')
+  const [url, setUrl] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const obstacles = useMemo(
+    () => toCroquisObstacles(parseCanyonWaypointsText(text)),
+    [text],
+  )
+
+  const base = name.trim() === '' ? 'croquis' : waypointSlug(name)
+  const filename = `croquis-${base}-${lang}`
+
+  async function handleImport() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await axios.get<{ data?: CanyonWaypoint[] }>(
+        '/api/cards/canyon-waypoints',
+        { params: { url } },
+      )
+      const wpts = res.data.data
+      if (!wpts) {
+        setError(t('cards.errors.gpxParse'))
+        return
+      }
+      if (wpts.length === 0) {
+        setError(t('cards.errors.noWaypointsFound'))
+        return
+      }
+      setText(serializeCanyonWaypoints(wpts))
+    } catch (err) {
+      setError(
+        isAxiosError(err)
+          ? (err.response?.data?.error ?? t('cards.errors.gpxParse'))
+          : t('cards.errors.gpxParse'),
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <StyledLayout data-testid="croquis-generator">
+      <StyledPanelForm>
+        <StyledForm>
+          <StyledLangToggle>
+            {LANGS.map((l) => (
+              <Button
+                key={l}
+                type="button"
+                variant="label"
+                active={lang === l}
+                onClick={() => setLang(l)}
+                data-testid={`cg-lang-${l}`}
+              >
+                {l.toUpperCase()}
+              </Button>
+            ))}
+          </StyledLangToggle>
+
+          <StyledSection>
+            <StyledSectionTitle>{t('cards.sections.files')}</StyledSectionTitle>
+            <FieldGroup>
+              <FieldLabel htmlFor="cg-name">
+                {t('cards.fields.fileNamePrefix')}
+              </FieldLabel>
+              <Input
+                id="cg-name"
+                value={name}
+                placeholder={t('cards.placeholders.canyonName')}
+                onChange={(e) => setName(e.target.value)}
+                data-testid="cg-name"
+              />
+              <FieldHelper>
+                {t('cards.fields.fileNamePrefixHelper')}
+              </FieldHelper>
+            </FieldGroup>
+          </StyledSection>
+
+          <StyledSection>
+            <StyledSectionTitle>{t('cards.sections.gpx')}</StyledSectionTitle>
+            <FieldGroup>
+              <FieldLabel htmlFor="cg-gpx">
+                {t('cards.fields.gpxUrl')}
+              </FieldLabel>
+              <StyledGpxRow>
+                <Input
+                  id="cg-gpx"
+                  value={url}
+                  placeholder={t('cards.placeholders.gpxUrl')}
+                  onChange={(e) => {
+                    setUrl(e.target.value)
+                    if (error) setError(null)
+                  }}
+                  data-testid="cg-gpx"
+                />
+                <Button
+                  type="button"
+                  variant="contained"
+                  colorScheme="success"
+                  size="sm"
+                  onClick={() => void handleImport()}
+                  disabled={!url || loading}
+                  data-testid="cg-import"
+                >
+                  {loading
+                    ? t('cards.actions.parsing')
+                    : t('cards.actions.parse')}
+                </Button>
+              </StyledGpxRow>
+              {error && (
+                <StyledError data-testid="cg-error">{error}</StyledError>
+              )}
+            </FieldGroup>
+          </StyledSection>
+
+          <StyledSection>
+            <StyledSectionTitle>
+              {t('cards.sections.waypointsText')}
+            </StyledSectionTitle>
+            <FieldGroup>
+              <FieldLabel htmlFor="cg-text">
+                {t('cards.fields.waypointsText')}
+              </FieldLabel>
+              <StyledTextarea
+                id="cg-text"
+                value={text}
+                placeholder={t('cards.placeholders.waypointsText')}
+                onChange={(e) => setText(e.target.value)}
+                data-testid="cg-text"
+              />
+            </FieldGroup>
+          </StyledSection>
+        </StyledForm>
+      </StyledPanelForm>
+
+      <StyledPanelPreview>
+        {obstacles.length > 0 ? (
+          <Croquis obstacles={obstacles} lang={lang} filename={filename} />
+        ) : (
+          <StyledEmpty data-testid="cg-empty">
+            {t('cards.croquis.empty')}
+          </StyledEmpty>
+        )}
+      </StyledPanelPreview>
+    </StyledLayout>
+  )
+}

--- a/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/index.ts
+++ b/apps/web/app/admin/(auth)/cards/components/CroquisGenerator/index.ts
@@ -1,0 +1,1 @@
+export { CroquisGenerator } from './CroquisGenerator'

--- a/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/CroquisInsertModal.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/CroquisInsertModal.spec.tsx
@@ -1,0 +1,312 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import axios, { AxiosError } from 'axios'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+import { CroquisInsertModal } from './CroquisInsertModal'
+
+function makeAxiosError(status: number, data: unknown): AxiosError {
+  return new AxiosError('error', String(status), undefined, undefined, {
+    status,
+    data,
+    statusText: 'Error',
+    headers: {},
+    config: {} as never,
+  })
+}
+
+jest.mock('@web/components/Croquis', () => ({
+  CroquisMap: () => <div data-testid="croquis-map-mock" />,
+}))
+
+jest.mock('@sdlgr/select', () => ({
+  Select: ({
+    value,
+    onChange,
+    options,
+    'data-testid': testId,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    options: Array<{ value: string; label: string }>
+    'data-testid'?: string
+    isSearchable?: boolean
+    maxMenuHeight?: number
+  }) => (
+    <select
+      data-testid={testId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">—</option>
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+jest.mock('../ImagePicker', () => ({
+  ImagePicker: ({
+    open,
+    onClose,
+    onPick,
+  }: {
+    open: boolean
+    onClose: () => void
+    onPick: (image: { url: string; publicId: string }) => void
+  }) =>
+    open ? (
+      <div data-testid="image-picker-mock">
+        <button
+          type="button"
+          data-testid="image-picker-pick"
+          onClick={() => onPick({ url: 'https://cdn/pick.jpg', publicId: 'p' })}
+        >
+          pick
+        </button>
+        <button
+          type="button"
+          data-testid="image-picker-close"
+          onClick={onClose}
+        >
+          close
+        </button>
+      </div>
+    ) : null,
+}))
+
+const JUMP = 'salto: Jump 2m - 42.6092 0.1412'
+
+function open(
+  props: Partial<React.ComponentProps<typeof CroquisInsertModal>> = {},
+) {
+  const onInsert = jest.fn()
+  const onCancel = jest.fn()
+  renderApp(
+    <CroquisInsertModal
+      isOpen
+      lang="en"
+      onInsert={onInsert}
+      onCancel={onCancel}
+      {...props}
+    />,
+  )
+  return { onInsert, onCancel }
+}
+
+afterEach(() => jest.restoreAllMocks())
+
+describe('CroquisInsertModal', () => {
+  it('renders the modal content when open', () => {
+    open()
+    expect(screen.getByTestId('croquis-modal')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-modal-text')).toBeInTheDocument()
+  })
+
+  it('prefills the textarea from initial values', () => {
+    open({ initialValues: { text: JUMP } })
+    expect(screen.getByTestId('croquis-modal-text')).toHaveValue(JUMP)
+  })
+
+  it('offers a waypoint selector and shows the preview once drawable', () => {
+    open()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: { value: JUMP },
+    })
+    expect(screen.getByTestId('croquis-wp-select')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-modal-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-map-mock')).toBeInTheDocument()
+  })
+
+  it('lists only drawable waypoints in the selector', () => {
+    open()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: {
+        value: 'salto: Jump 2m - 42.6 0.1\n---\ninfo: A view - 42.6 0.1',
+      },
+    })
+    expect(screen.getByText('salto: Jump 2m')).toBeInTheDocument()
+    expect(screen.queryByText('info: A view')).not.toBeInTheDocument()
+  })
+
+  it('disables Insert without drawable obstacles and enables it with one', () => {
+    open()
+    const insert = screen.getByTestId('croquis-modal-insert')
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: { value: 'info: A view - 42.6 0.1' },
+    })
+    expect(insert).toBeDisabled()
+    expect(
+      screen.queryByTestId('croquis-modal-preview'),
+    ).not.toBeInTheDocument()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: { value: JUMP },
+    })
+    expect(insert).not.toBeDisabled()
+  })
+
+  it('inserts a croquis fence with the waypoint text', () => {
+    const { onInsert } = open()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: { value: JUMP },
+    })
+    fireEvent.click(screen.getByTestId('croquis-modal-insert'))
+    expect(onInsert).toHaveBeenCalledTimes(1)
+    const md = onInsert.mock.calls[0][0]
+    expect(md).toContain('```croquis')
+    expect(md).toContain(JUMP)
+  })
+
+  it('selects a waypoint, picks an image, and rides it in the markdown', () => {
+    const { onInsert } = open()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: { value: JUMP },
+    })
+    // Pick is disabled until a waypoint is chosen.
+    expect(screen.getByTestId('croquis-wp-pick')).toBeDisabled()
+    fireEvent.change(screen.getByTestId('croquis-wp-select'), {
+      target: { value: '0' },
+    })
+    fireEvent.click(screen.getByTestId('croquis-wp-pick'))
+    fireEvent.click(screen.getByTestId('image-picker-pick'))
+    // The waypoint moves to the mappings list with its thumb.
+    expect(screen.getByTestId('croquis-wp-thumb-0')).toHaveAttribute(
+      'src',
+      'https://cdn/pick.jpg',
+    )
+    fireEvent.click(screen.getByTestId('croquis-modal-insert'))
+    expect(onInsert.mock.calls[0][0]).toContain('img=https://cdn/pick.jpg')
+  })
+
+  it('closes the image picker without picking', () => {
+    open()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: { value: JUMP },
+    })
+    fireEvent.change(screen.getByTestId('croquis-wp-select'), {
+      target: { value: '0' },
+    })
+    fireEvent.click(screen.getByTestId('croquis-wp-pick'))
+    expect(screen.getByTestId('image-picker-mock')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('image-picker-close'))
+    expect(screen.queryByTestId('image-picker-mock')).not.toBeInTheDocument()
+  })
+
+  it('assigns an image to one waypoint among several', () => {
+    open()
+    fireEvent.change(screen.getByTestId('croquis-modal-text'), {
+      target: {
+        value: `${JUMP}\n---\nrapel: Rappel 10m - 42.6056 0.1294`,
+      },
+    })
+    fireEvent.change(screen.getByTestId('croquis-wp-select'), {
+      target: { value: '1' },
+    })
+    fireEvent.click(screen.getByTestId('croquis-wp-pick'))
+    fireEvent.click(screen.getByTestId('image-picker-pick'))
+    expect(screen.getByTestId('croquis-wp-thumb-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('croquis-wp-thumb-0')).not.toBeInTheDocument()
+  })
+
+  it('removes a waypoint image', () => {
+    open({ initialValues: { text: `${JUMP}\n! img=https://cdn/x.jpg` } })
+    expect(screen.getByTestId('croquis-wp-thumb-0')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('croquis-wp-remove-0'))
+    expect(screen.queryByTestId('croquis-wp-thumb-0')).not.toBeInTheDocument()
+  })
+
+  it('cancels', () => {
+    const { onCancel } = open()
+    fireEvent.click(screen.getByTestId('croquis-modal-cancel'))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  describe('GPX parse', () => {
+    function enterUrl() {
+      fireEvent.change(screen.getByTestId('croquis-modal-gpx'), {
+        target: { value: 'https://x/y.gpx' },
+      })
+    }
+
+    it('fills the textarea from parsed waypoints', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({
+        data: { data: [{ categories: ['salto'], title: 'Jump', notes: [] }] },
+      })
+      open()
+      enterUrl()
+      fireEvent.click(screen.getByTestId('croquis-modal-parse'))
+      await waitFor(() =>
+        expect(screen.getByTestId('croquis-modal-text')).toHaveValue(
+          'salto: Jump',
+        ),
+      )
+    })
+
+    it('errors when the response has no waypoints', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({ data: { data: [] } })
+      open()
+      enterUrl()
+      fireEvent.click(screen.getByTestId('croquis-modal-parse'))
+      expect(
+        await screen.findByTestId('croquis-modal-error'),
+      ).toBeInTheDocument()
+    })
+
+    it('shows the server error message', async () => {
+      jest
+        .spyOn(axios, 'get')
+        .mockRejectedValue(makeAxiosError(400, { error: 'Bad GPX' }))
+      open()
+      enterUrl()
+      fireEvent.click(screen.getByTestId('croquis-modal-parse'))
+      expect(
+        await screen.findByTestId('croquis-modal-error'),
+      ).toHaveTextContent('Bad GPX')
+    })
+
+    it('falls back to a generic error when the axios error has no message', async () => {
+      jest.spyOn(axios, 'get').mockRejectedValue(makeAxiosError(500, {}))
+      open()
+      enterUrl()
+      fireEvent.click(screen.getByTestId('croquis-modal-parse'))
+      expect(
+        await screen.findByTestId('croquis-modal-error'),
+      ).toHaveTextContent('Could not parse GPX file')
+    })
+
+    it('falls back to a generic error for non-axios failures', async () => {
+      jest.spyOn(axios, 'get').mockRejectedValue(new Error('boom'))
+      open()
+      enterUrl()
+      fireEvent.click(screen.getByTestId('croquis-modal-parse'))
+      expect(
+        await screen.findByTestId('croquis-modal-error'),
+      ).toBeInTheDocument()
+    })
+
+    it('shows a parsing label and clears a prior error on url change', async () => {
+      let resolve!: (v: unknown) => void
+      jest.spyOn(axios, 'get').mockReturnValue(
+        new Promise((r) => {
+          resolve = r
+        }),
+      )
+      open()
+      enterUrl()
+      const parse = screen.getByTestId('croquis-modal-parse')
+      fireEvent.click(parse)
+      await waitFor(() => expect(parse).toHaveTextContent('Parsing…'))
+      resolve({ data: { data: [] } })
+      await screen.findByTestId('croquis-modal-error')
+      fireEvent.change(screen.getByTestId('croquis-modal-gpx'), {
+        target: { value: 'https://x/z.gpx' },
+      })
+      expect(
+        screen.queryByTestId('croquis-modal-error'),
+      ).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/CroquisInsertModal.styles.ts
+++ b/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/CroquisInsertModal.styles.ts
@@ -1,0 +1,181 @@
+import { Modal as ModalOverlays } from 'react-overlays'
+import styled from 'styled-components'
+
+import { Button } from '@sdlgr/button'
+
+export const StyledBackdrop = styled.div`
+  position: fixed;
+  z-index: 1040;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: ${({ theme }) => theme.colors.black};
+  opacity: 0.7;
+`
+
+export const StyledCroquisModal = styled(ModalOverlays)`
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: 1040;
+  border: 1px solid ${({ theme }) => theme.colors.green};
+  box-shadow: 0 0 16px 4px rgba(152, 223, 214, 0.5);
+  border-radius: 2px;
+  background-color: ${({ theme }) => theme.colors.black};
+  overflow-y: auto;
+
+  ${({ theme }) => theme.media.up.md} {
+    top: 5vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    height: auto;
+    max-width: min(900px, 90vw);
+    max-height: 90vh;
+  }
+`
+
+export const StyledModalContent = styled.div`
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`
+
+export const StyledSectionLabel = styled.p`
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.5;
+  color: ${({ theme }) => theme.colors.white};
+  margin: 0;
+`
+
+export const StyledGpxRow = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+
+  > *:first-child {
+    flex: 1;
+  }
+`
+
+export const StyledInput = styled.input`
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  color: ${({ theme }) => theme.colors.white};
+  font-family: inherit;
+  font-size: 0.8rem;
+  padding: 0.45rem 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+
+  &::placeholder {
+    opacity: 0.35;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledTextarea = styled.textarea`
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  color: ${({ theme }) => theme.colors.white};
+  font-family: monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  padding: 0.6rem 0.75rem;
+  width: 100%;
+  min-height: 160px;
+  resize: vertical;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledError = styled.p`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.orange};
+  margin: 0;
+`
+
+export const StyledParseButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  border-color: rgba(128, 128, 128, 0.35);
+  border-radius: 4px;
+  color: ${({ theme }) => theme.colors.white};
+  font-size: 0.72rem;
+  opacity: 0.75;
+  padding: 0 0.7rem;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    border-color: ${({ theme }) => theme.colors.green};
+  }
+`
+
+export const StyledPreviewBox = styled.div`
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 0.5rem;
+`
+
+export const StyledButtons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+`
+
+export const StyledCancelButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  padding: 0.375rem 0.875rem;
+  color: ${({ theme }) => theme.colors.white};
+  border-color: rgba(255, 255, 255, 0.25);
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  &:hover {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+`
+
+export const StyledInsertButton = styled(Button).attrs({
+  variant: 'ghost',
+  size: 'xs',
+})`
+  padding: 0.375rem 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${({ theme }) => theme.colors.green};
+  border-color: ${({ theme }) => theme.colors.green};
+
+  &:hover:not(:disabled) {
+    box-shadow: 0 0 8px 1px rgba(152, 223, 214, 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+`

--- a/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/CroquisInsertModal.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/CroquisInsertModal.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import axios, { isAxiosError } from 'axios'
+import { useState } from 'react'
+import { RenderModalBackdropProps } from 'react-overlays/Modal'
+
+import { Select } from '@sdlgr/select'
+
+import { CroquisMap } from '@web/components/Croquis'
+import {
+  isDrawableWaypoint,
+  parseCanyonWaypointsText,
+  serializeCanyonWaypoints,
+  toCroquisObstacles,
+} from '@web/lib/cards'
+import type { CanyonWaypoint, Lang } from '@web/lib/cards'
+import type { CloudinaryImage } from '@web/lib/cloudinary/images'
+
+import {
+  StyledAddRow,
+  StyledMappingName,
+  StyledMappingRow,
+  StyledMappingThumb,
+  StyledMappingsList,
+  StyledPickImageButton,
+  StyledRemoveButton,
+  StyledWaypointImagesSection,
+} from '../GpxMapModal/GpxMapModal.styles'
+import { ImagePicker } from '../ImagePicker'
+import type { ParsedCroquis } from '../PostEditor/parseEmbedBlock'
+import {
+  StyledBackdrop,
+  StyledButtons,
+  StyledCancelButton,
+  StyledCroquisModal,
+  StyledError,
+  StyledGpxRow,
+  StyledInput,
+  StyledInsertButton,
+  StyledModalContent,
+  StyledParseButton,
+  StyledPreviewBox,
+  StyledSectionLabel,
+  StyledTextarea,
+} from './CroquisInsertModal.styles'
+
+interface IndexedWaypoint {
+  wp: CanyonWaypoint
+  index: number
+}
+
+export interface CroquisInsertModalProps {
+  isOpen: boolean
+  onInsert: (markdown: string) => void
+  onCancel: () => void
+  initialValues?: ParsedCroquis | null
+  lang: Lang
+}
+
+/**
+ * Builds a `croquis` block for the post: the waypoint text (typed or imported
+ * from a GPX url) plus a photo picked per waypoint (shown on hover). The photo
+ * rides along in each waypoint's `! … ; img=…` directive.
+ */
+export function CroquisInsertModal({
+  isOpen,
+  onInsert,
+  onCancel,
+  initialValues,
+  lang,
+}: CroquisInsertModalProps) {
+  const [text, setText] = useState(initialValues?.text ?? '')
+  const [url, setUrl] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [pickingFor, setPickingFor] = useState<number | null>(null)
+  const [pending, setPending] = useState<number | undefined>(undefined)
+
+  const waypoints = parseCanyonWaypointsText(text)
+  const obstacles = toCroquisObstacles(waypoints)
+
+  // Only waypoints actually drawn in the croquis can carry a hover image.
+  const drawable: IndexedWaypoint[] = waypoints
+    .map((wp, index) => ({ wp, index }))
+    .filter(({ wp }) => isDrawableWaypoint(wp.categories))
+  const mapped = drawable.filter(({ wp }) => wp.photo)
+  const available = drawable.filter(({ wp }) => !wp.photo)
+
+  function writeWaypoints(next: CanyonWaypoint[]) {
+    setText(serializeCanyonWaypoints(next))
+  }
+
+  function setPhoto(index: number, photo: string | undefined) {
+    writeWaypoints(
+      waypoints.map((w, i) => {
+        if (i !== index) return w
+        if (photo) return { ...w, photo }
+        const next = { ...w }
+        delete next.photo
+        return next
+      }),
+    )
+  }
+
+  async function handleParse() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await axios.get<{ data?: CanyonWaypoint[] }>(
+        '/api/cards/canyon-waypoints',
+        { params: { url } },
+      )
+      const wpts = res.data.data
+      if (!wpts || wpts.length === 0) {
+        setError('Could not parse GPX file')
+        return
+      }
+      setText(serializeCanyonWaypoints(wpts))
+    } catch (err) {
+      setError(
+        isAxiosError(err)
+          ? (err.response?.data?.error ?? 'Could not parse GPX file')
+          : 'Could not parse GPX file',
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function pickForPending() {
+    /* istanbul ignore next */
+    if (pending === undefined) return
+    setPickingFor(pending)
+  }
+
+  function handleImagePick(image: CloudinaryImage) {
+    /* istanbul ignore next */
+    if (pickingFor === null) return
+    setPhoto(pickingFor, image.url)
+    setPickingFor(null)
+    setPending(undefined)
+  }
+
+  function handleInsert() {
+    /* istanbul ignore next */
+    if (obstacles.length === 0) return
+    onInsert(`\n\n\`\`\`croquis\n${text.trim()}\n\`\`\`\n\n`)
+    setText('')
+    setUrl('')
+    setError(null)
+    setPickingFor(null)
+  }
+
+  return (
+    <>
+      <StyledCroquisModal
+        show={isOpen}
+        onHide={onCancel}
+        renderBackdrop={
+          pickingFor !== null
+            ? undefined
+            : (props: RenderModalBackdropProps) => <StyledBackdrop {...props} />
+        }
+        aria-labelledby="croquis-insert-modal"
+      >
+        <StyledModalContent data-testid="croquis-modal">
+          <StyledSectionLabel>GPX url (optional)</StyledSectionLabel>
+          <StyledGpxRow>
+            <StyledInput
+              type="url"
+              value={url}
+              onChange={(e) => {
+                setUrl(e.target.value)
+                if (error) setError(null)
+              }}
+              placeholder="https://your-cdn.com/canyon.gpx"
+              data-testid="croquis-modal-gpx"
+            />
+            <StyledParseButton
+              type="button"
+              onClick={() => void handleParse()}
+              disabled={!url || loading}
+              data-testid="croquis-modal-parse"
+            >
+              {loading ? 'Parsing…' : 'Parse'}
+            </StyledParseButton>
+          </StyledGpxRow>
+          {error && (
+            <StyledError data-testid="croquis-modal-error">{error}</StyledError>
+          )}
+
+          <StyledSectionLabel>Waypoints</StyledSectionLabel>
+          <StyledTextarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={
+              'salto: Jump 2m - 42.6092 0.1412\n- Bend on landing\n---\nrapel: Rappel 10m - 42.6056 0.1294'
+            }
+            data-testid="croquis-modal-text"
+          />
+
+          {drawable.length > 0 && (
+            <StyledWaypointImagesSection data-testid="croquis-modal-waypoints">
+              <StyledSectionLabel>Waypoint images</StyledSectionLabel>
+
+              {mapped.length > 0 && (
+                <StyledMappingsList>
+                  {mapped.map(({ wp, index }) => (
+                    <StyledMappingRow
+                      key={index}
+                      data-testid={`croquis-wp-row-${index}`}
+                    >
+                      <StyledMappingThumb
+                        src={wp.photo}
+                        alt={wp.title}
+                        data-testid={`croquis-wp-thumb-${index}`}
+                      />
+                      <StyledMappingName>
+                        {wp.categories.join('/')}: {wp.title}
+                      </StyledMappingName>
+                      <StyledRemoveButton
+                        type="button"
+                        aria-label={`Remove image for ${wp.title}`}
+                        onClick={() => setPhoto(index, undefined)}
+                        data-testid={`croquis-wp-remove-${index}`}
+                      >
+                        ×
+                      </StyledRemoveButton>
+                    </StyledMappingRow>
+                  ))}
+                </StyledMappingsList>
+              )}
+
+              {available.length > 0 && (
+                <StyledAddRow>
+                  <Select
+                    value={pending !== undefined ? String(pending) : ''}
+                    onChange={(v) =>
+                      setPending(
+                        v !== ''
+                          ? parseInt(v, 10)
+                          : /* istanbul ignore next */ undefined,
+                      )
+                    }
+                    options={available.map(({ wp, index }) => ({
+                      value: String(index),
+                      label: `${wp.categories.join('/')}: ${wp.title}`,
+                    }))}
+                    isSearchable
+                    maxMenuHeight={160}
+                    data-testid="croquis-wp-select"
+                  />
+                  <StyledPickImageButton
+                    type="button"
+                    disabled={pending === undefined}
+                    onClick={pickForPending}
+                    data-testid="croquis-wp-pick"
+                  >
+                    Pick image
+                  </StyledPickImageButton>
+                </StyledAddRow>
+              )}
+            </StyledWaypointImagesSection>
+          )}
+
+          {obstacles.length > 0 && (
+            <StyledPreviewBox data-testid="croquis-modal-preview">
+              <CroquisMap obstacles={obstacles} lang={lang} />
+            </StyledPreviewBox>
+          )}
+
+          <StyledButtons>
+            <StyledCancelButton
+              onClick={onCancel}
+              data-testid="croquis-modal-cancel"
+            >
+              Cancel
+            </StyledCancelButton>
+            <StyledInsertButton
+              onClick={handleInsert}
+              disabled={obstacles.length === 0}
+              data-testid="croquis-modal-insert"
+            >
+              Insert
+            </StyledInsertButton>
+          </StyledButtons>
+        </StyledModalContent>
+      </StyledCroquisModal>
+
+      <ImagePicker
+        open={pickingFor !== null}
+        onClose={() => setPickingFor(null)}
+        onPick={handleImagePick}
+        zIndex={1100}
+      />
+    </>
+  )
+}

--- a/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/index.ts
+++ b/apps/web/app/admin/(auth)/posts/components/CroquisInsertModal/index.ts
@@ -1,0 +1,2 @@
+export { CroquisInsertModal } from './CroquisInsertModal'
+export type { CroquisInsertModalProps } from './CroquisInsertModal'

--- a/apps/web/app/admin/(auth)/posts/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/MarkdownPreview/MarkdownPreview.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 import { CodeBlock } from '@sdlgr/code-block'
 
 import { MdxTable } from '@web/components/PostContent/MdxTable'
+import { PostContentCroquis } from '@web/components/PostContent/PostContentCroquis'
 import { PostContentEmbed } from '@web/components/PostContent/PostContentEmbed'
 import { PostContentImage } from '@web/components/PostContent/PostContentImage'
 import { PostContentSlideshow } from '@web/components/PostContent/PostContentSlideshow'
@@ -46,6 +47,7 @@ const MDX_COMPONENTS = {
   img: PostContentImage,
   Embed: PostContentEmbed,
   Slideshow: PostContentSlideshow,
+  Croquis: PostContentCroquis,
   h1: H1AsH2,
   table: TableComponent,
 }

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.embed.spec.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.embed.spec.tsx
@@ -203,6 +203,37 @@ jest.mock('../SlideshowInsertModal', () => ({
     ) : null,
 }))
 
+jest.mock('../CroquisInsertModal', () => ({
+  CroquisInsertModal: ({
+    isOpen,
+    onInsert,
+    onCancel,
+  }: {
+    isOpen: boolean
+    onInsert: (markdown: string) => void
+    onCancel: () => void
+    [key: string]: unknown
+  }) =>
+    isOpen ? (
+      <div data-testid="croquis-insert-modal-mock">
+        <button
+          type="button"
+          data-testid="croquis-modal-insert-mock"
+          onClick={() => onInsert('\n\n```croquis\nsalto: Jump 2m\n```\n\n')}
+        >
+          Insert
+        </button>
+        <button
+          type="button"
+          data-testid="croquis-modal-cancel-mock"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}))
+
 jest.mock('../ImagePicker', () => ({
   ImagePicker: () => null,
 }))
@@ -478,6 +509,67 @@ describe('PostEditor embed edit-in-place', () => {
     fireEvent.click(screen.getByTestId('edit-embed-button'))
     fireEvent.click(screen.getByTestId('gpx-modal-cancel-mock'))
     expect(screen.queryByTestId('gpx-map-modal-mock')).not.toBeInTheDocument()
+  })
+
+  it('opens the croquis modal from the toolbar and inserts a block', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    fireEvent.change(screen.getByTestId('content-input'), {
+      target: { value: 'Intro' },
+    })
+    fireEvent.click(screen.getByTestId('open-croquis-modal-button'))
+    expect(screen.getByTestId('croquis-insert-modal-mock')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('croquis-modal-insert-mock'))
+    expect(
+      (screen.getByTestId('content-input') as HTMLTextAreaElement).value,
+    ).toContain('```croquis')
+  })
+
+  it('shows edit button when cursor is inside a croquis block', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content = 'Intro\n\n```croquis\nsalto: Jump 2m\n```\n\nOutro'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```croquis') + 3
+    textarea.selectionEnd = content.indexOf('```croquis') + 3
+    fireEvent.click(textarea)
+    expect(screen.getByTestId('edit-embed-button')).toHaveTextContent(
+      'Edit croquis',
+    )
+  })
+
+  it('opens the croquis modal when editing a croquis block and replaces it', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content = 'Before\n\n```croquis\nsalto: Old 3m\n```\n\nAfter'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```croquis') + 3
+    textarea.selectionEnd = content.indexOf('```croquis') + 3
+    fireEvent.click(textarea)
+    fireEvent.click(screen.getByTestId('edit-embed-button'))
+    expect(screen.getByTestId('croquis-insert-modal-mock')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('croquis-modal-insert-mock'))
+    const newContent = (
+      screen.getByTestId('content-input') as HTMLTextAreaElement
+    ).value
+    expect(newContent).not.toContain('Old 3m')
+    expect(newContent).toContain('Before')
+    expect(newContent).toContain('After')
+    expect(newContent).toContain('Jump 2m')
+  })
+
+  it('cancel on croquis modal during edit clears initialValues', () => {
+    renderApp(<PostEditor categories={mockCategories} users={mockUsers} />)
+    const textarea = screen.getByTestId('content-input') as HTMLTextAreaElement
+    const content = 'Intro\n\n```croquis\nsalto: Jump 2m\n```\n\nOutro'
+    fireEvent.change(textarea, { target: { value: content } })
+    textarea.selectionStart = content.indexOf('```croquis') + 3
+    textarea.selectionEnd = content.indexOf('```croquis') + 3
+    fireEvent.click(textarea)
+    fireEvent.click(screen.getByTestId('edit-embed-button'))
+    fireEvent.click(screen.getByTestId('croquis-modal-cancel-mock'))
+    expect(
+      screen.queryByTestId('croquis-insert-modal-mock'),
+    ).not.toBeInTheDocument()
   })
 
   it('shows edit button when cursor is inside a slideshow block', () => {

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/PostEditor.tsx
@@ -30,6 +30,7 @@ import { computeReadingTime } from '@web/utils/computeReadingTime'
 import { slugify } from '@web/utils/slugify'
 
 import { PublishNotifyModal } from '../../../components/PublishNotifyModal'
+import { CroquisInsertModal } from '../CroquisInsertModal'
 import { EmbedInsertModal } from '../EmbedInsertModal'
 import { GpxMapModal } from '../GpxMapModal'
 import { ImageInsertModal } from '../ImageInsertModal'
@@ -83,6 +84,7 @@ import {
 } from './PostEditor.styles'
 import type {
   DetectedEmbed,
+  ParsedCroquis,
   ParsedEmbed,
   ParsedGpx,
   ParsedImage,
@@ -286,6 +288,10 @@ export function PostEditor({
   const [slideshowModalKey, setSlideshowModalKey] = useState(0)
   const [slideshowInitialValues, setSlideshowInitialValues] =
     useState<ParsedSlideshow | null>(null)
+  const [isCroquisModalOpen, setIsCroquisModalOpen] = useState(false)
+  const [croquisModalKey, setCroquisModalKey] = useState(0)
+  const [croquisInitialValues, setCroquisInitialValues] =
+    useState<ParsedCroquis | null>(null)
   const [previewTab, setPreviewTab] = useState<
     'post' | 'post-mobile' | 'hero' | 'card' | 'toc'
   >('post')
@@ -367,6 +373,10 @@ export function PostEditor({
       setSlideshowInitialValues(editingEmbed.parsed as ParsedSlideshow)
       setSlideshowModalKey((k) => k + 1)
       setIsSlideshowModalOpen(true)
+    } else if (editingEmbed.type === 'croquis') {
+      setCroquisInitialValues(editingEmbed.parsed as ParsedCroquis)
+      setCroquisModalKey((k) => k + 1)
+      setIsCroquisModalOpen(true)
     } else {
       setGpxInitialValues(editingEmbed.parsed as ParsedGpx)
       setGpxModalKey((k) => k + 1)
@@ -970,6 +980,18 @@ export function PostEditor({
               >
                 Insert Slideshow
               </StyledImagePickerButton>
+              <StyledImagePickerButton
+                type="button"
+                onClick={() => {
+                  setEditingEmbed(null)
+                  setCroquisInitialValues(null)
+                  setCroquisModalKey((k) => k + 1)
+                  setIsCroquisModalOpen(true)
+                }}
+                data-testid="open-croquis-modal-button"
+              >
+                Insert Croquis
+              </StyledImagePickerButton>
             </StyledToolbarRow>
             <StyledTextareaWrapper>
               <StyledContentTextarea
@@ -1246,6 +1268,29 @@ export function PostEditor({
         onRequestImagePick={(onPicked) => {
           contentPickerCallbackRef.current = onPicked
           setIsContentPickerOpen(true)
+        }}
+      />
+      <CroquisInsertModal
+        key={`croquis-${croquisModalKey}`}
+        isOpen={isCroquisModalOpen}
+        initialValues={croquisInitialValues}
+        lang={activeLocale}
+        onInsert={(markdown) => {
+          if (editingEmbed?.type === 'croquis') {
+            replaceBlock(
+              editingEmbed.blockStart,
+              editingEmbed.blockEnd,
+              markdown,
+            )
+          } else {
+            insertAtCursor(markdown)
+          }
+          setIsCroquisModalOpen(false)
+          setCroquisInitialValues(null)
+        }}
+        onCancel={() => {
+          setIsCroquisModalOpen(false)
+          setCroquisInitialValues(null)
         }}
       />
       <PublishNotifyModal

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.spec.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.spec.ts
@@ -485,6 +485,37 @@ describe('detectEmbedAtCursor', () => {
     })
   })
 
+  describe('croquis blocks', () => {
+    const croquisContent = [
+      'Intro',
+      '',
+      '```croquis',
+      'salto: Jump 2m - 42.6 0.1',
+      '! img=https://img.com/jump.jpg',
+      '```',
+      '',
+      'Outro',
+    ].join('\n')
+
+    it('detects a croquis block when the cursor is inside', () => {
+      const fenceStart = croquisContent.indexOf('```croquis')
+      const result = detectEmbedAtCursor(croquisContent, fenceStart + 5)
+      expect(result?.type).toBe('croquis')
+    })
+
+    it('carries the block body text verbatim', () => {
+      const fenceStart = croquisContent.indexOf('```croquis')
+      const result = detectEmbedAtCursor(croquisContent, fenceStart + 5)
+      if (result?.type !== 'croquis') throw new Error('expected croquis')
+      expect(result.parsed.text).toContain('salto: Jump 2m - 42.6 0.1')
+      expect(result.parsed.text).toContain('! img=https://img.com/jump.jpg')
+    })
+
+    it('returns null when the cursor is outside the croquis block', () => {
+      expect(detectEmbedAtCursor(croquisContent, 2)).toBeNull()
+    })
+  })
+
   it('returns null for plain text content', () => {
     expect(detectEmbedAtCursor('Just some plain text here.', 5)).toBeNull()
   })

--- a/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.ts
+++ b/apps/web/app/admin/(auth)/posts/components/PostEditor/parseEmbedBlock.ts
@@ -47,6 +47,11 @@ export interface ParsedSlideshow {
   slides: ParsedSlideshowSlide[]
 }
 
+/** A croquis block carries the editable canyon-waypoint text verbatim. */
+export interface ParsedCroquis {
+  text: string
+}
+
 export type DetectedEmbed =
   | { type: 'image'; blockStart: number; blockEnd: number; parsed: ParsedImage }
   | { type: 'embed'; blockStart: number; blockEnd: number; parsed: ParsedEmbed }
@@ -56,6 +61,12 @@ export type DetectedEmbed =
       blockStart: number
       blockEnd: number
       parsed: ParsedSlideshow
+    }
+  | {
+      type: 'croquis'
+      blockStart: number
+      blockEnd: number
+      parsed: ParsedCroquis
     }
 
 const EMBED_TYPES: EmbedType[] = [
@@ -241,6 +252,15 @@ export function detectEmbedAtCursor(
           blockStart: start,
           blockEnd: end,
           parsed: { slides },
+        }
+      }
+
+      if (fenceType === 'croquis') {
+        return {
+          type: 'croquis',
+          blockStart: start,
+          blockEnd: end,
+          parsed: { text: body },
         }
       }
 

--- a/apps/web/components/Croquis/CroquisMap.spec.tsx
+++ b/apps/web/components/Croquis/CroquisMap.spec.tsx
@@ -1,0 +1,233 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+import type { CroquisObstacle } from '@web/lib/cards'
+
+import { CroquisMap } from './CroquisMap'
+
+afterEach(() => jest.useRealTimers())
+
+function ob(overrides: Partial<CroquisObstacle> = {}): CroquisObstacle {
+  return {
+    type: 'salto',
+    title: 'Jump one',
+    meters: 5,
+    side: null,
+    severity: 'easy',
+    notes: [],
+    ...overrides,
+  }
+}
+
+describe('CroquisMap', () => {
+  it('renders one interactive group per obstacle', () => {
+    renderApp(
+      <CroquisMap obstacles={[ob(), ob({ title: 'Second' })]} lang="en" />,
+    )
+    expect(screen.getByTestId('croquis-svg')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-obstacle-0')).toBeInTheDocument()
+    expect(screen.getByTestId('croquis-obstacle-1')).toBeInTheDocument()
+  })
+
+  it('opens the popover on mouse enter and closes shortly after leave', () => {
+    jest.useFakeTimers()
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    const popover = screen.getByTestId('croquis-popover')
+    expect(popover).toHaveAttribute('data-open', 'false')
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(popover).toHaveAttribute('data-open', 'true')
+    expect(screen.getByText('Jump one')).toBeInTheDocument()
+    fireEvent.mouseLeave(screen.getByTestId('croquis-obstacle-0'))
+    // Deferred: still open right after leaving.
+    expect(popover).toHaveAttribute('data-open', 'true')
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    expect(popover).toHaveAttribute('data-open', 'false')
+  })
+
+  it('keeps the popover open while the mouse is over it', () => {
+    jest.useFakeTimers()
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    const popover = screen.getByTestId('croquis-popover')
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    fireEvent.mouseLeave(screen.getByTestId('croquis-obstacle-0'))
+    // Mouse travels into the popover before the close timer fires.
+    fireEvent.mouseEnter(popover)
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    expect(popover).toHaveAttribute('data-open', 'true')
+    // Leaving the popover then closes it.
+    fireEvent.mouseLeave(popover)
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    expect(popover).toHaveAttribute('data-open', 'false')
+  })
+
+  it('opens on tap (click) for touch devices', () => {
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.click(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'true',
+    )
+  })
+
+  it('closes when tapping outside any obstacle', () => {
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.click(screen.getByTestId('croquis-obstacle-0'))
+    fireEvent.pointerDown(document.body)
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'false',
+    )
+  })
+
+  it('stays open when the pointer-down lands on an obstacle', () => {
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.click(screen.getByTestId('croquis-obstacle-0'))
+    fireEvent.pointerDown(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'true',
+    )
+  })
+
+  it('closes on Escape but ignores other keys', () => {
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.click(screen.getByTestId('croquis-obstacle-0'))
+    fireEvent.keyDown(document, { key: 'a' })
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'true',
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'false',
+    )
+  })
+
+  it('opens on focus and closes on blur', () => {
+    jest.useFakeTimers()
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.focus(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'true',
+    )
+    fireEvent.blur(screen.getByTestId('croquis-obstacle-0'))
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    expect(screen.getByTestId('croquis-popover')).toHaveAttribute(
+      'data-open',
+      'false',
+    )
+  })
+
+  it('shows the obstacle photo when present', () => {
+    renderApp(
+      <CroquisMap obstacles={[ob({ photo: 'https://x/y.jpg' })]} lang="en" />,
+    )
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    const img = screen.getByAltText('Jump one') as HTMLImageElement
+    expect(img.src).toBe('https://x/y.jpg')
+  })
+
+  it('falls back to a drawn scene without a photo', () => {
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('shows metres, side and severity chips', () => {
+    renderApp(
+      <CroquisMap
+        obstacles={[ob({ meters: 8, side: 'left', severity: 'danger' })]}
+        lang="en"
+      />,
+    )
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByText('8 m')).toBeInTheDocument()
+    expect(screen.getByText('LEFT')).toBeInTheDocument()
+    expect(screen.getByText('DANGER')).toBeInTheDocument()
+  })
+
+  it('shows the right-side label and caution severity', () => {
+    renderApp(
+      <CroquisMap
+        obstacles={[ob({ side: 'right', severity: 'caution' })]}
+        lang="en"
+      />,
+    )
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByText('RIGHT')).toBeInTheDocument()
+    expect(screen.getByText('CAUTION')).toBeInTheDocument()
+  })
+
+  it('omits the metres chip when unknown', () => {
+    renderApp(<CroquisMap obstacles={[ob({ meters: null })]} lang="en" />)
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.queryByText(/ m$/)).not.toBeInTheDocument()
+  })
+
+  it('lists the notes', () => {
+    renderApp(
+      <CroquisMap
+        obstacles={[ob({ notes: [{ text: 'Aim centre', sub: false }] })]}
+        lang="en"
+      />,
+    )
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByText('Aim centre')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['rapel', 'RAPPEL'],
+    ['tobogan', 'SLIDE'],
+    ['salto', 'JUMP'],
+    ['salto-rapel', 'JUMP / RAPPEL'],
+  ] as const)('labels a %s obstacle as %s', (type, label) => {
+    renderApp(<CroquisMap obstacles={[ob({ type })]} lang="en" />)
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it('translates the popover to Spanish', () => {
+    renderApp(<CroquisMap obstacles={[ob({ type: 'rapel' })]} lang="es" />)
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    expect(screen.getByText('RÁPEL')).toBeInTheDocument()
+  })
+
+  it('positions the popover below when there is no room above', () => {
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    const popover = screen.getByTestId('croquis-popover')
+    expect(popover.style.top).toBe('12px')
+    expect(popover.style.left).toBe('8px')
+  })
+
+  it('positions the popover above and clamps a far-right element', () => {
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 400,
+      bottom: 450,
+      left: 2000,
+      right: 2100,
+      width: 100,
+      height: 50,
+      x: 2000,
+      y: 400,
+      toJSON: () => ({}),
+    } as DOMRect)
+    renderApp(<CroquisMap obstacles={[ob()]} lang="en" />)
+    fireEvent.mouseEnter(screen.getByTestId('croquis-obstacle-0'))
+    const popover = screen.getByTestId('croquis-popover')
+    expect(popover.style.top).toBe('138px')
+    expect(Number.parseInt(popover.style.left, 10)).toBeLessThan(2000)
+    jest.restoreAllMocks()
+  })
+})

--- a/apps/web/components/Croquis/CroquisMap.styles.ts
+++ b/apps/web/components/Croquis/CroquisMap.styles.ts
@@ -1,0 +1,149 @@
+import styled from 'styled-components'
+
+export const StyledFrame = styled.div`
+  position: relative;
+  border: 1px solid #223442;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #14212c 0%, #0d161d 100%);
+  box-shadow: 0 24px 60px -30px #000;
+  /* Never let the frame shrink below its aspect-ratio height in a flex column. */
+  flex-shrink: 0;
+`
+
+export const StyledScroll = styled.div<{ $ratio: number }>`
+  width: 100%;
+  /* aspect-ratio gives a definite height (svg height:auto is unreliable) so a
+     tall serpentine croquis keeps its full height and never clips. */
+  aspect-ratio: ${({ $ratio }) => $ratio};
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+`
+
+export const StyledObstacle = styled.g`
+  cursor: pointer;
+  outline: none;
+
+  .glow {
+    opacity: 0;
+    transition: opacity 0.18s;
+  }
+
+  &:hover .glow,
+  &:focus-visible .glow {
+    opacity: 1;
+  }
+
+  .ring {
+    opacity: 0;
+  }
+
+  &:focus-visible .ring {
+    opacity: 1;
+  }
+`
+
+export const StyledPopover = styled.div<{ $hasPhoto: boolean }>`
+  position: fixed;
+  width: ${({ $hasPhoto }) => ($hasPhoto ? '320px' : '260px')};
+  background: #101c26;
+  border: 1px solid #2f4a5a;
+  border-radius: 14px;
+  box-shadow: 0 20px 50px -20px #000;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity 0.16s,
+    transform 0.16s;
+  pointer-events: none;
+  /* Portalled to <body>; must sit above the insert modal (1040) and picker (1100). */
+  z-index: 1200;
+
+  &[data-open='true'] {
+    opacity: 1;
+    transform: translateY(0);
+    /* Interactive while open so hovering it keeps it from closing. */
+    pointer-events: auto;
+  }
+
+  .media {
+    height: ${({ $hasPhoto }) => ($hasPhoto ? '200px' : '128px')};
+    background: #0a1218;
+    border-bottom: 1px solid #223442;
+  }
+
+  .media svg,
+  .media img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .body {
+    padding: 0.75rem 0.85rem 0.9rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`
+
+export const StyledKind = styled.p`
+  font-family: monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: ${({ theme }) => theme.colors.orange};
+  margin: 0 0 0.15rem;
+`
+
+export const StyledName = styled.p`
+  font-size: 1rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.white};
+  margin: 0 0 0.5rem;
+`
+
+export const StyledChips = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.55rem;
+`
+
+export const StyledChip = styled.span`
+  font-family: monospace;
+  font-size: 0.72rem;
+  padding: 0.16rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid #2f4a5a;
+  color: ${({ theme }) => theme.colors.white};
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+`
+
+export const StyledNotes = styled.ul`
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #93a7b2;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  list-style: disc;
+
+  li {
+    margin: 0.1rem 0;
+  }
+`

--- a/apps/web/components/Croquis/CroquisMap.tsx
+++ b/apps/web/components/Croquis/CroquisMap.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import {
+  AMBER,
+  CROQUIS_WIDTH,
+  FONT_STYLE,
+  SEV_COLORS,
+  STRINGS,
+  croquisBackground,
+  croquisConnectors,
+  croquisNodeContent,
+  layoutCroquis,
+  scene,
+} from '@web/lib/cards'
+import type { CroquisObstacle, CroquisType, Lang } from '@web/lib/cards'
+
+import {
+  StyledChip,
+  StyledChips,
+  StyledFrame,
+  StyledKind,
+  StyledName,
+  StyledNotes,
+  StyledObstacle,
+  StyledPopover,
+  StyledScroll,
+} from './CroquisMap.styles'
+
+const FLOW_STYLE =
+  '<style>.flow{stroke-dasharray:10 14;animation:croquis-flow 1.6s linear infinite}' +
+  '@keyframes croquis-flow{to{stroke-dashoffset:-48}}' +
+  '@media (prefers-reduced-motion: reduce){.flow{animation:none}}</style>'
+
+type S = (typeof STRINGS)[Lang]
+
+/** Category label for the popover heading. */
+function kindLabel(type: CroquisType, s: S): string {
+  const c = s.categories
+  if (type === 'salto-rapel') return `${c.salto} / ${c.rappel}`
+  if (type === 'rapel') return c.rappel
+  if (type === 'tobogan') return c.tobogan
+  return c.salto
+}
+
+function sevLabel(severity: CroquisObstacle['severity'], s: S): string {
+  if (severity === 'danger') return s.sev_danger
+  if (severity === 'caution') return s.sev_caution
+  return s.sev_easy
+}
+
+export interface CroquisMapProps {
+  obstacles: CroquisObstacle[]
+  lang: Lang
+}
+
+/**
+ * The interactive croquis map: the river course drawn from obstacles, with a
+ * hover/focus popover per element (its photo when available, else a drawn
+ * scene). Presentational and read-only — export/upload live in the caller.
+ */
+export function CroquisMap({ obstacles, lang }: CroquisMapProps) {
+  const strings = STRINGS[lang]
+  const [active, setActive] = useState<number | null>(null)
+  const [pos, setPos] = useState({ left: 0, top: 0 })
+  // Deferred close so the mouse can travel from the obstacle into the popover
+  // (which sits a few px away) without it closing in the gap.
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function cancelClose() {
+    if (closeTimer.current !== null) {
+      clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+  function scheduleClose() {
+    cancelClose()
+    closeTimer.current = setTimeout(() => setActive(null), 160)
+  }
+  useEffect(() => () => cancelClose(), [])
+  // The popover is portalled to <body> so its position:fixed is anchored to the
+  // viewport, not to a transformed ancestor (e.g. the centred insert modal).
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true)
+  }, [])
+
+  // Touch has no hover: a tap opens the popover, and a tap outside any obstacle
+  // (or Escape) closes it. On desktop, hover still opens/closes it directly.
+  useEffect(() => {
+    if (active === null) return
+    const close = () => setActive(null)
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Element
+      if (!target.closest('[data-croquis-obstacle],[data-croquis-popover]')) {
+        close()
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [active])
+
+  const layout = useMemo(
+    () => layoutCroquis(obstacles, CROQUIS_WIDTH),
+    [obstacles],
+  )
+  const bg = useMemo(
+    () => croquisBackground(layout.width, layout.height),
+    [layout],
+  )
+  const connectors = useMemo(
+    () => croquisConnectors(layout, strings),
+    [layout, strings],
+  )
+
+  function open(index: number, target: SVGGElement) {
+    cancelClose()
+    const r = target.getBoundingClientRect()
+    const hasPhoto = Boolean(obstacles[index].photo)
+    const pw = hasPhoto ? 320 : 260
+    const ph = hasPhoto ? 320 : 250
+    const gap = 12
+    let left = r.left + r.width / 2 - pw / 2
+    left = Math.max(8, Math.min(window.innerWidth - pw - 8, left))
+    let top = r.top - gap - ph
+    if (top < 8) top = Math.min(r.bottom + gap, window.innerHeight - ph - 8)
+    top = Math.max(8, top)
+    setPos({ left, top })
+    setActive(index)
+  }
+
+  const obstacle = active !== null ? obstacles[active] : null
+
+  const popover = (
+    <StyledPopover
+      data-testid="croquis-popover"
+      data-croquis-popover=""
+      data-open={obstacle !== null}
+      $hasPhoto={Boolean(obstacle?.photo)}
+      style={{ left: pos.left, top: pos.top }}
+      onMouseEnter={cancelClose}
+      onMouseLeave={scheduleClose}
+    >
+      {obstacle && (
+        <>
+          <div className="media">
+            {obstacle.photo ? (
+              <img src={obstacle.photo} alt={obstacle.title} />
+            ) : (
+              <div dangerouslySetInnerHTML={{ __html: scene(obstacle.type) }} />
+            )}
+          </div>
+          <div className="body">
+            <StyledKind>{kindLabel(obstacle.type, strings)}</StyledKind>
+            <StyledName>{obstacle.title}</StyledName>
+            <StyledChips>
+              {obstacle.meters !== null && (
+                <StyledChip>{obstacle.meters} m</StyledChip>
+              )}
+              {obstacle.side && (
+                <StyledChip>
+                  {obstacle.side === 'left'
+                    ? strings.side_left
+                    : strings.side_right}
+                </StyledChip>
+              )}
+              <StyledChip>
+                <span
+                  className="dot"
+                  style={{ background: SEV_COLORS[obstacle.severity] }}
+                />
+                {sevLabel(obstacle.severity, strings)}
+              </StyledChip>
+            </StyledChips>
+            {obstacle.notes.length > 0 && (
+              <StyledNotes>
+                {obstacle.notes.map((note, i) => (
+                  <li key={i}>{note.text}</li>
+                ))}
+              </StyledNotes>
+            )}
+          </div>
+        </>
+      )}
+    </StyledPopover>
+  )
+
+  return (
+    <>
+      <StyledFrame>
+        <StyledScroll $ratio={layout.width / layout.height}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox={`0 0 ${layout.width} ${layout.height}`}
+            preserveAspectRatio="xMidYMid meet"
+            data-testid="croquis-svg"
+          >
+            <defs
+              dangerouslySetInnerHTML={{ __html: FONT_STYLE + FLOW_STYLE }}
+            />
+            <g dangerouslySetInnerHTML={{ __html: bg }} />
+            <g dangerouslySetInnerHTML={{ __html: connectors }} />
+            {layout.nodes.map((node) => (
+              <StyledObstacle
+                key={node.index}
+                tabIndex={0}
+                role="button"
+                aria-label={node.obstacle.title}
+                data-croquis-obstacle=""
+                data-testid={`croquis-obstacle-${node.index}`}
+                onMouseEnter={(e) => open(node.index, e.currentTarget)}
+                onMouseLeave={scheduleClose}
+                onFocus={(e) => open(node.index, e.currentTarget)}
+                onBlur={scheduleClose}
+                onClick={(e) => open(node.index, e.currentTarget)}
+              >
+                <rect
+                  className="glow"
+                  x={node.box.x}
+                  y={node.box.y}
+                  width={node.box.w}
+                  height={node.box.h}
+                  rx={12}
+                  fill={AMBER}
+                  fillOpacity={0.1}
+                />
+                <g
+                  dangerouslySetInnerHTML={{
+                    __html: croquisNodeContent(node, strings),
+                  }}
+                />
+                <rect
+                  className="ring"
+                  x={node.box.x - 2}
+                  y={node.box.y - 2}
+                  width={node.box.w + 4}
+                  height={node.box.h + 4}
+                  rx={13}
+                  fill="none"
+                  stroke={AMBER}
+                  strokeWidth={1.5}
+                />
+                <rect
+                  className="hit"
+                  x={node.box.x}
+                  y={node.box.y}
+                  width={node.box.w}
+                  height={node.box.h}
+                  fill="transparent"
+                />
+              </StyledObstacle>
+            ))}
+          </svg>
+        </StyledScroll>
+      </StyledFrame>
+
+      {mounted && createPortal(popover, document.body)}
+    </>
+  )
+}

--- a/apps/web/components/Croquis/index.ts
+++ b/apps/web/components/Croquis/index.ts
@@ -1,0 +1,2 @@
+export { CroquisMap } from './CroquisMap'
+export type { CroquisMapProps } from './CroquisMap'

--- a/apps/web/components/PostContent/PostContentCroquis.spec.tsx
+++ b/apps/web/components/PostContent/PostContentCroquis.spec.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react'
+
+import { renderApp } from '@sdlgr/test-utils'
+
+import { PostContentCroquis } from './PostContentCroquis'
+
+jest.mock('@web/components/Croquis', () => ({
+  CroquisMap: ({ obstacles, lang }: { obstacles: unknown[]; lang: string }) => (
+    <div data-testid="croquis-map-mock">
+      <span data-testid="cm-count">{obstacles.length}</span>
+      <span data-testid="cm-lang">{lang}</span>
+    </div>
+  ),
+}))
+
+let mockLanguage = 'en'
+jest.mock('@web/i18n/client', () => ({
+  useClientTranslation: () => ({ i18n: { language: mockLanguage } }),
+}))
+
+const OB = JSON.stringify([
+  {
+    type: 'salto',
+    title: 'Jump',
+    meters: 5,
+    side: null,
+    severity: 'easy',
+    notes: [],
+  },
+])
+
+describe('PostContentCroquis', () => {
+  beforeEach(() => {
+    mockLanguage = 'en'
+  })
+
+  it('renders nothing without obstacles', () => {
+    renderApp(<PostContentCroquis />)
+    expect(screen.queryByTestId('post-croquis')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for an empty obstacle list', () => {
+    renderApp(<PostContentCroquis obstacles="[]" />)
+    expect(screen.queryByTestId('post-croquis')).not.toBeInTheDocument()
+  })
+
+  it('renders the map with the parsed obstacles', () => {
+    renderApp(<PostContentCroquis obstacles={OB} />)
+    expect(screen.getByTestId('post-croquis')).toBeInTheDocument()
+    expect(screen.getByTestId('cm-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('cm-lang')).toHaveTextContent('en')
+  })
+
+  it('passes the Spanish language through', () => {
+    mockLanguage = 'es'
+    renderApp(<PostContentCroquis obstacles={OB} />)
+    expect(screen.getByTestId('cm-lang')).toHaveTextContent('es')
+  })
+})

--- a/apps/web/components/PostContent/PostContentCroquis.styles.ts
+++ b/apps/web/components/PostContent/PostContentCroquis.styles.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const StyledCroquisWrapper = styled.div`
+  margin: 2rem 0;
+`

--- a/apps/web/components/PostContent/PostContentCroquis.tsx
+++ b/apps/web/components/PostContent/PostContentCroquis.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { CroquisMap } from '@web/components/Croquis'
+import { useClientTranslation } from '@web/i18n/client'
+import type { CroquisObstacle, Lang } from '@web/lib/cards'
+
+import { StyledCroquisWrapper } from './PostContentCroquis.styles'
+
+/**
+ * Renders an interactive canyon croquis embedded in post content. `obstacles`
+ * arrives as a JSON string from the remark transform; the map itself is the
+ * shared read-only CroquisMap, localised to the current post language.
+ */
+export function PostContentCroquis({ obstacles }: { obstacles?: string }) {
+  const { i18n } = useClientTranslation('common')
+
+  if (!obstacles) return null
+  const parsed = JSON.parse(obstacles) as CroquisObstacle[]
+  if (parsed.length === 0) return null
+
+  const lang: Lang = i18n.language === 'es' ? 'es' : 'en'
+
+  return (
+    <StyledCroquisWrapper data-testid="post-croquis">
+      <CroquisMap obstacles={parsed} lang={lang} />
+    </StyledCroquisWrapper>
+  )
+}

--- a/apps/web/i18n/locales/en/admin.json
+++ b/apps/web/i18n/locales/en/admin.json
@@ -351,6 +351,7 @@
       "route": "Route",
       "canyonData": "Canyon",
       "canyonWaypoints": "Canyon (waypoints)",
+      "croquis": "Croquis",
       "ferrata": "Via Ferrata",
       "waypointsGpx": "Waypoints (GPX)",
       "waypointSingle": "Waypoint (single)"
@@ -453,6 +454,9 @@
       "noWaypoints": "No waypoints with elevation found",
       "noWaypointsFound": "No waypoints found",
       "upload": "Upload failed"
+    },
+    "croquis": {
+      "empty": "Add jump, rappel or slide waypoints above to draw the croquis. Hover an element to see it."
     }
   }
 }

--- a/apps/web/lib/cards/canyonWaypointCard.ts
+++ b/apps/web/lib/cards/canyonWaypointCard.ts
@@ -118,13 +118,13 @@ function noteLines(notes: CanyonWaypointNote[]): NoteLine[] {
 }
 
 /** Pull the first "<n> m" height mention from a title (e.g. "Rappel 10m"). */
-function extractMeters(title: string): string | null {
+export function extractMeters(title: string): string | null {
   const m = /(\d+(?:[.,]\d+)?)\s*m\b/i.exec(title)
   return m ? `${m[1].replace(',', '.')} m` : null
 }
 
 /** Detect a left/right side mention (ES/EN) in a title. */
-function extractSide(title: string): 'left' | 'right' | null {
+export function extractSide(title: string): 'left' | 'right' | null {
   const n = norm(title)
   if (/\b(izquierda|izqda|izda|izq|left)\b/.test(n)) return 'left'
   if (/\b(derecha|dcha|dcho|right)\b/.test(n)) return 'right'
@@ -164,7 +164,10 @@ const CAUTION_KEYS = [
 ]
 
 /** Grade a waypoint's risk from its title + notes wording. Red beats amber. */
-function severity(title: string, notes: CanyonWaypointNote[]): Severity {
+export function detectSeverity(
+  title: string,
+  notes: CanyonWaypointNote[],
+): Severity {
   const hay = norm([title, ...notes.map((n) => n.text)].join(' \n '))
   if (DANGER_KEYS.some((k) => hay.includes(k))) return 'danger'
   if (CAUTION_KEYS.some((k) => hay.includes(k))) return 'caution'
@@ -247,7 +250,7 @@ export function canyonWaypointCard(data: CanyonWaypointCardData): {
   const cats: Record<string, string> = S.categories
   const catLabel = data.categories.map((c) => cats[c] ?? cats.info).join(' / ')
 
-  const sev: Severity = data.severity ?? severity(data.title, data.notes)
+  const sev: Severity = data.severity ?? detectSeverity(data.title, data.notes)
   const meters = data.meters ?? extractMeters(data.title)
   const side = data.side ?? extractSide(data.title)
   const sevColor = SEV_COLORS[sev]

--- a/apps/web/lib/cards/canyonWaypoints.spec.ts
+++ b/apps/web/lib/cards/canyonWaypoints.spec.ts
@@ -131,6 +131,14 @@ describe('parseCanyonWaypointsText', () => {
     expect(wp.notes).toEqual([{ text: 'Fuerte corriente', sub: false }])
   })
 
+  it('parses an img directive into the waypoint photo', () => {
+    const [wp] = parseCanyonWaypointsText(
+      'salto: Salto - 42.6 0.1\n! side=right; img=https://cdn/x.jpg',
+    )
+    expect(wp.photo).toBe('https://cdn/x.jpg')
+    expect(wp.side).toBe('right')
+  })
+
   it('ignores unknown or malformed directive tokens', () => {
     const [wp] = parseCanyonWaypointsText(
       'rapel: R1 - 42.6 0.1\n! side=up; sev=zzz; foo; m=; x=1',
@@ -276,6 +284,22 @@ describe('serializeCanyonWaypoints', () => {
     expect(
       parseCanyonWaypointsText(serializeCanyonWaypoints(original)),
     ).toEqual(original)
+  })
+
+  it('emits and round-trips an img directive for the photo', () => {
+    const original: CanyonWaypoint[] = [
+      {
+        categories: ['salto'],
+        title: 'Salto',
+        lat: 42.6,
+        lon: 0.1,
+        notes: [],
+        photo: 'https://cdn/x.jpg',
+      },
+    ]
+    const text = serializeCanyonWaypoints(original)
+    expect(text).toBe('salto: Salto - 42.6 0.1\n! img=https://cdn/x.jpg')
+    expect(parseCanyonWaypointsText(text)).toEqual(original)
   })
 
   it('omits coordinates when absent', () => {

--- a/apps/web/lib/cards/canyonWaypoints.ts
+++ b/apps/web/lib/cards/canyonWaypoints.ts
@@ -27,13 +27,16 @@ export interface CanyonWaypoint {
   severity?: CanyonSeverity
   /** Manual override for the drop-height pill (else parsed from the title). */
   meters?: string
+  /** Illustrative photo shown when hovering the obstacle in a croquis. */
+  photo?: string
 }
 
-/** Parsed manual overrides carried by a `! side=…; sev=…; m=…` directive. */
+/** Parsed manual overrides carried by a `! side=…; sev=…; m=…; img=…` directive. */
 interface Overrides {
   side?: CanyonSide
   severity?: CanyonSeverity
   meters?: string
+  photo?: string
 }
 
 /** Category-prefix word (normalized, `/`-stripped) → category key. */
@@ -141,6 +144,7 @@ function parseDirective(line: string): Overrides {
     )
       out.severity = val
     else if (key === 'm') out.meters = val
+    else if (key === 'img') out.photo = val
   }
   return out
 }
@@ -157,6 +161,7 @@ function parseBody(
       if (d.side) over.side = d.side
       if (d.severity) over.severity = d.severity
       if (d.meters) over.meters = d.meters
+      if (d.photo) over.photo = d.photo
     } else {
       const n = parseNote(line)
       if (n) notes.push(n)
@@ -174,6 +179,7 @@ function buildWaypoint(
   if (body.side) wp.side = body.side
   if (body.severity) wp.severity = body.severity
   if (body.meters) wp.meters = body.meters
+  if (body.photo) wp.photo = body.photo
   return wp
 }
 
@@ -251,6 +257,7 @@ export function serializeCanyonWaypoints(waypoints: CanyonWaypoint[]): string {
       if (w.side) dir.push(`side=${w.side}`)
       if (w.severity) dir.push(`sev=${w.severity}`)
       if (w.meters) dir.push(`m=${w.meters}`)
+      if (w.photo) dir.push(`img=${w.photo}`)
       const notes = w.notes.map((n) => `${n.sub ? ' ' : ''}- ${n.text}`)
       const lines = [head]
       if (dir.length) lines.push(`! ${dir.join('; ')}`)

--- a/apps/web/lib/cards/croquisCard.spec.ts
+++ b/apps/web/lib/cards/croquisCard.spec.ts
@@ -1,0 +1,116 @@
+import {
+  croquisBackground,
+  croquisCard,
+  croquisConnectors,
+  croquisNodeContent,
+} from './croquisCard'
+import type { CroquisObstacle } from './croquisData'
+import { layoutCroquis } from './croquisLayout'
+import { STRINGS } from './theme'
+
+function ob(overrides: Partial<CroquisObstacle> = {}): CroquisObstacle {
+  return {
+    type: 'salto',
+    title: 'Jump',
+    meters: 5,
+    side: null,
+    severity: 'easy',
+    notes: [],
+    ...overrides,
+  }
+}
+
+const EN = STRINGS.en
+
+describe('croquisBackground', () => {
+  it('draws contour polylines sized to the height', () => {
+    const s = croquisBackground(600, 480)
+    expect((s.match(/<polyline/g) ?? []).length).toBe(Math.ceil(480 / 120))
+  })
+})
+
+describe('croquisConnectors', () => {
+  it('returns nothing for an empty layout', () => {
+    expect(croquisConnectors(layoutCroquis([]), EN)).toBe('')
+  })
+
+  it('draws the access and exit markers', () => {
+    const s = croquisConnectors(layoutCroquis([ob()]), EN)
+    expect(s).toContain('ACCESS')
+    expect(s).toContain('EXIT')
+  })
+
+  it('localises the markers', () => {
+    const s = croquisConnectors(layoutCroquis([ob()]), STRINGS.es)
+    expect(s).toContain('ACCESO')
+    expect(s).toContain('SALIDA')
+  })
+})
+
+describe('croquisNodeContent', () => {
+  it('labels a rappel with its category, not a number', () => {
+    const [n] = layoutCroquis([ob({ type: 'rapel', title: 'Cascade' })]).nodes
+    const s = croquisNodeContent(n, EN)
+    expect(s).toContain('>Rappel<')
+    expect(s).not.toContain('>R1<')
+  })
+
+  it('labels a combo with both categories', () => {
+    const [n] = layoutCroquis([
+      ob({ type: 'salto-rapel', title: 'Jump or rappel' }),
+    ]).nodes
+    expect(croquisNodeContent(n, EN)).toContain('>Jump / Rappel<')
+  })
+
+  it('labels other obstacles with the first title word', () => {
+    const [n] = layoutCroquis([ob({ title: 'Big jump' })]).nodes
+    expect(croquisNodeContent(n, EN)).toContain('>Big<')
+  })
+
+  it('falls back to a dash for an empty title', () => {
+    const [n] = layoutCroquis([ob({ title: '' })]).nodes
+    expect(croquisNodeContent(n, EN)).toContain('>—<')
+  })
+
+  it('shows metres and a left-side marker', () => {
+    const [n] = layoutCroquis([ob({ meters: 8, side: 'left' })]).nodes
+    const s = croquisNodeContent(n, EN)
+    expect(s).toContain('8 m')
+    expect(s).toContain(`◄ ${EN.side_left}`)
+  })
+
+  it('shows a right-side marker', () => {
+    const [n] = layoutCroquis([ob({ side: 'right' })]).nodes
+    expect(croquisNodeContent(n, EN)).toContain(`${EN.side_right} ►`)
+  })
+
+  it('omits the metrics line when there is nothing to show', () => {
+    const [n] = layoutCroquis([ob({ meters: null, side: null })]).nodes
+    const s = croquisNodeContent(n, EN)
+    expect(s).not.toContain(' m<')
+  })
+})
+
+describe('croquisCard', () => {
+  it('returns a valid SVG sized to the layout', () => {
+    const { svg, width, height } = croquisCard([ob()], 'en')
+    expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+    expect(svg).toContain('</svg>')
+    expect(svg).toContain(`viewBox="0 0 ${width} ${height}"`)
+  })
+
+  it('embeds the card fonts', () => {
+    expect(croquisCard([ob()], 'en').svg).toContain('@font-face')
+  })
+
+  it('renders one glyph set per obstacle', () => {
+    const { svg } = croquisCard([ob({ type: 'rapel' }), ob()], 'en')
+    expect(svg).toContain('Rappel')
+  })
+
+  it('respects the requested drawing width in serpentine mode', () => {
+    const obstacles = Array.from({ length: 10 }, () => ob())
+    const { width } = croquisCard(obstacles, 'en', 1200)
+    expect(width).toBe(1200)
+  })
+})

--- a/apps/web/lib/cards/croquisCard.ts
+++ b/apps/web/lib/cards/croquisCard.ts
@@ -1,0 +1,139 @@
+import type { CroquisObstacle } from './croquisData'
+import { glyphFor, river, rowReturn } from './croquisGlyphs'
+import {
+  type CroquisLayout,
+  type CroquisNode,
+  layoutCroquis,
+} from './croquisLayout'
+import { FONT_STYLE } from './fonts'
+import { esc } from './primitives'
+import {
+  AMBER,
+  BG_BOT,
+  BG_TOP,
+  BONE,
+  COLD,
+  CONTOUR,
+  type Lang,
+  type LangStrings,
+  PANEL_STK,
+  SEV_COLORS,
+  STRINGS,
+} from './theme'
+
+/** Sine-wave contour lines sized to the whole croquis, for background texture. */
+export function croquisBackground(width: number, height: number): string {
+  const rows = Math.ceil(height / 120)
+  let bg = ''
+  for (let r = 0; r < rows; r++) {
+    const base = 50 + r * 120
+    const pts: string[] = []
+    for (let i = 0; i <= width; i += 24) {
+      pts.push(`${i},${(base + Math.sin(i * 0.012 + r) * 10).toFixed(1)}`)
+    }
+    bg += `<polyline points="${pts.join(' ')}" fill="none" stroke="${CONTOUR}" stroke-width="1.4" opacity="0.45"/>`
+  }
+  return bg
+}
+
+/** The river connectors plus the access and exit markers. */
+export function croquisConnectors(
+  layout: CroquisLayout,
+  S: LangStrings,
+): string {
+  if (layout.nodes.length === 0) return ''
+  const links = layout.segments
+    .map((s) =>
+      s.kind === 'return'
+        ? rowReturn(s.x1, s.y1, s.x2, s.y2)
+        : river(s.x1, s.y1, s.x2, s.y2),
+    )
+    .join('')
+  const { access, exit } = layout
+  const accessMark =
+    `<text x="${access.x - 70}" y="${access.y - 30}" fill="${COLD}" font-family="Roboto Mono" font-size="13" letter-spacing="2">${esc(S.croquis_access)}</text>` +
+    `<path d="M${access.x - 64} ${access.y - 20} l0 14 m-6 -6 l6 6 l6 -6" stroke="${COLD}" stroke-width="2" fill="none"/>`
+  const exitMark =
+    `<path d="M${exit.x} ${exit.y} l14 0 m-6 -6 l6 6 l-6 6" stroke="${COLD}" stroke-width="2" fill="none"/>` +
+    `<text x="${exit.x + 22}" y="${exit.y + 5}" fill="${COLD}" font-family="Roboto Mono" font-size="13" letter-spacing="2">${esc(S.croquis_exit)}</text>`
+  return links + accessMark + exitMark
+}
+
+/** Short "12 m · ◄ IZDA" descriptor beneath an obstacle. */
+function metaLabel(node: CroquisNode, S: LangStrings): string {
+  const parts: string[] = []
+  if (node.obstacle.meters != null) parts.push(`${node.obstacle.meters} m`)
+  if (node.obstacle.side === 'left') parts.push(`◄ ${S.side_left}`)
+  else if (node.obstacle.side === 'right') parts.push(`${S.side_right} ►`)
+  return parts.join('  ·  ')
+}
+
+/** Title-case a category label (e.g. "RÁPEL" → "Rápel"). */
+function titleCase(s: string): string {
+  return s.charAt(0) + s.slice(1).toLowerCase()
+}
+
+/**
+ * The name shown above an obstacle: both categories for a combo (e.g.
+ * "Salto / Rápel"), the rappel category for a rappel, else the first title word.
+ */
+function nodeLabel(node: CroquisNode, S: LangStrings): string {
+  if (node.obstacle.type === 'salto-rapel') {
+    return `${titleCase(S.categories.salto)} / ${titleCase(S.categories.rappel)}`
+  }
+  if (node.obstacle.type === 'rapel') return titleCase(S.categories.rappel)
+  return node.obstacle.title.split(/\s+/)[0] || '—'
+}
+
+/** Glyph + severity dot + name + metrics for one obstacle (no hit region). */
+export function croquisNodeContent(node: CroquisNode, S: LangStrings): string {
+  const sev = SEV_COLORS[node.obstacle.severity]
+  const glyph = glyphFor(
+    node.obstacle.type,
+    node.x,
+    node.yTop,
+    node.endX,
+    node.yBot,
+  )
+  const meta = metaLabel(node, S)
+  const metaSvg = meta
+    ? `<text x="${((node.x + node.endX) / 2).toFixed(1)}" y="${node.yBot + 30}" text-anchor="middle" fill="${COLD}" font-family="Roboto Mono" font-size="12">${esc(meta)}</text>`
+    : ''
+  return (
+    glyph +
+    `<circle cx="${node.x}" cy="${node.yTop - 28}" r="5" fill="${sev}"/>` +
+    `<text x="${node.x + 11}" y="${node.yTop - 23}" fill="${BONE}" font-family="Poppins" font-weight="700" font-size="15">${esc(nodeLabel(node, S))}</text>` +
+    metaSvg
+  )
+}
+
+/**
+ * Render the full static croquis SVG for a set of obstacles, ready to be
+ * rasterised to a PNG. `width` sets the drawing width (serpentine rows fill it).
+ */
+export function croquisCard(
+  obstacles: CroquisObstacle[],
+  lang: Lang,
+  width?: number,
+): { svg: string; width: number; height: number } {
+  const S = STRINGS[lang]
+  const layout = layoutCroquis(obstacles, width)
+  const W = layout.width
+  const H = layout.height
+  const nodes = layout.nodes.map((n) => croquisNodeContent(n, S)).join('')
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">
+<defs>
+ ${FONT_STYLE}
+ <linearGradient id="panel" x1="0" y1="0" x2="0.35" y2="1"><stop offset="0" stop-color="${BG_TOP}"/><stop offset="1" stop-color="${BG_BOT}"/></linearGradient>
+ <clipPath id="pc"><rect x="8" y="8" width="${W - 16}" height="${H - 16}" rx="28"/></clipPath>
+</defs>
+<rect x="8" y="8" width="${W - 16}" height="${H - 16}" rx="28" fill="url(#panel)" stroke="${PANEL_STK}" stroke-width="1.6"/>
+<g clip-path="url(#pc)">${croquisBackground(W, H)}</g>
+<rect x="8" y="80" width="6" height="80" rx="3" fill="${AMBER}"/>
+${croquisConnectors(layout, S)}
+${nodes}
+</svg>`
+
+  return { svg, width: W, height: H }
+}

--- a/apps/web/lib/cards/croquisData.spec.ts
+++ b/apps/web/lib/cards/croquisData.spec.ts
@@ -1,0 +1,137 @@
+import type { CanyonWaypoint } from './canyonWaypoints'
+import { isDrawableWaypoint, toCroquisObstacles } from './croquisData'
+
+function wp(overrides: Partial<CanyonWaypoint>): CanyonWaypoint {
+  return { categories: ['salto'], title: 'Jump', notes: [], ...overrides }
+}
+
+describe('toCroquisObstacles', () => {
+  it('drops waypoints that are not jump / rappel / slide', () => {
+    const out = toCroquisObstacles([
+      wp({ categories: ['info'], title: 'View' }),
+      wp({ categories: ['poza'], title: 'Pool' }),
+      wp({ categories: ['destrepe'], title: 'Downclimb' }),
+      wp({ categories: ['salto'], title: 'Jump' }),
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].title).toBe('Jump')
+  })
+
+  it('resolves each single category to its glyph type', () => {
+    const out = toCroquisObstacles([
+      wp({ categories: ['rappel'], title: 'R' }),
+      wp({ categories: ['salto'], title: 'S' }),
+      wp({ categories: ['tobogan'], title: 'T' }),
+    ])
+    expect(out.map((o) => o.type)).toEqual(['rapel', 'salto', 'tobogan'])
+  })
+
+  it('combines rappel + jump into a split gesture', () => {
+    const out = toCroquisObstacles([
+      wp({ categories: ['rappel', 'salto'], title: 'R/S' }),
+    ])
+    expect(out[0].type).toBe('salto-rapel')
+  })
+
+  it('prefers the slide when tobogan and jump are combined', () => {
+    const out = toCroquisObstacles([
+      wp({ categories: ['tobogan', 'salto'], title: 'T/S' }),
+    ])
+    expect(out[0].type).toBe('tobogan')
+  })
+
+  it('reads the drop height from an explicit override', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump', meters: '12' })])
+    expect(out[0].meters).toBe(12)
+  })
+
+  it('parses a comma decimal override', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump', meters: '3,5' })])
+    expect(out[0].meters).toBe(3.5)
+  })
+
+  it('falls back to metres parsed from the title', () => {
+    const out = toCroquisObstacles([
+      wp({ title: 'Rappel 10m', categories: ['rappel'] }),
+    ])
+    expect(out[0].meters).toBe(10)
+  })
+
+  it('leaves metres null when neither override nor title has a height', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump' })])
+    expect(out[0].meters).toBeNull()
+  })
+
+  it('uses the side override when present', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump', side: 'left' })])
+    expect(out[0].side).toBe('left')
+  })
+
+  it('detects the side from the title otherwise', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump on the derecha' })])
+    expect(out[0].side).toBe('right')
+  })
+
+  it('leaves side null when nothing indicates one', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump' })])
+    expect(out[0].side).toBeNull()
+  })
+
+  it('uses the severity override when present', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump', severity: 'danger' })])
+    expect(out[0].severity).toBe('danger')
+  })
+
+  it('detects severity from the wording otherwise', () => {
+    const out = toCroquisObstacles([
+      wp({ title: 'Jump', notes: [{ text: 'peligro de rebufo', sub: false }] }),
+    ])
+    expect(out[0].severity).toBe('danger')
+  })
+
+  it('defaults severity to easy for calm wording', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump' })])
+    expect(out[0].severity).toBe('easy')
+  })
+
+  it('carries the waypoint photo through when present', () => {
+    const out = toCroquisObstacles([
+      wp({ title: 'Jump', photo: 'https://x/y.jpg' }),
+    ])
+    expect(out[0].photo).toBe('https://x/y.jpg')
+  })
+
+  it('leaves photo undefined when the waypoint has none', () => {
+    const out = toCroquisObstacles([wp({ title: 'Jump' })])
+    expect(out[0].photo).toBeUndefined()
+  })
+
+  it('carries notes and coordinates through', () => {
+    const out = toCroquisObstacles([
+      wp({
+        title: 'Jump',
+        lat: 42.6,
+        lon: 0.14,
+        notes: [{ text: 'Aim centre', sub: false }],
+      }),
+    ])
+    expect(out[0].lat).toBe(42.6)
+    expect(out[0].lon).toBe(0.14)
+    expect(out[0].notes).toEqual([{ text: 'Aim centre', sub: false }])
+  })
+})
+
+describe('isDrawableWaypoint', () => {
+  it('is true for jump / rappel / slide and combos', () => {
+    expect(isDrawableWaypoint(['salto'])).toBe(true)
+    expect(isDrawableWaypoint(['rappel'])).toBe(true)
+    expect(isDrawableWaypoint(['tobogan'])).toBe(true)
+    expect(isDrawableWaypoint(['rappel', 'salto'])).toBe(true)
+  })
+
+  it('is false for other categories', () => {
+    expect(isDrawableWaypoint(['info'])).toBe(false)
+    expect(isDrawableWaypoint(['destrepe'])).toBe(false)
+    expect(isDrawableWaypoint([])).toBe(false)
+  })
+})

--- a/apps/web/lib/cards/croquisData.ts
+++ b/apps/web/lib/cards/croquisData.ts
@@ -1,0 +1,80 @@
+import {
+  detectSeverity,
+  extractMeters,
+  extractSide,
+} from './canyonWaypointCard'
+import type {
+  CanyonSeverity,
+  CanyonSide,
+  CanyonWaypoint,
+  CanyonWaypointNote,
+} from './canyonWaypoints'
+
+/** Obstacle gestures the croquis can draw. A rappel + jump combines to a split. */
+export type CroquisType = 'rapel' | 'tobogan' | 'salto' | 'salto-rapel'
+
+/** A canyon waypoint reduced to what the croquis needs to draw and annotate. */
+export interface CroquisObstacle {
+  type: CroquisType
+  title: string
+  /** Drop height in metres (drives the glyph size), or null when unknown. */
+  meters: number | null
+  side: CanyonSide | null
+  severity: CanyonSeverity
+  notes: CanyonWaypointNote[]
+  lat?: number
+  lon?: number
+  /** Optional illustrative photo shown on hover; falls back to a drawn scene. */
+  photo?: string
+}
+
+/** Resolve the glyph type from a waypoint's category keys (null → not drawn). */
+function resolveType(categories: string[]): CroquisType | null {
+  const hasR = categories.includes('rappel')
+  const hasT = categories.includes('tobogan')
+  const hasS = categories.includes('salto')
+  if (hasR && hasS) return 'salto-rapel'
+  if (hasR) return 'rapel'
+  if (hasT) return 'tobogan'
+  if (hasS) return 'salto'
+  return null
+}
+
+/** Whether a waypoint (by its categories) is drawn in the croquis. */
+export function isDrawableWaypoint(categories: string[]): boolean {
+  return resolveType(categories) !== null
+}
+
+/** Resolve a numeric drop height from an explicit override or the title text. */
+function resolveMeters(wp: CanyonWaypoint): number | null {
+  const raw = wp.meters ?? extractMeters(wp.title) ?? ''
+  const n = parseFloat(raw.replace(',', '.'))
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Reduce parsed canyon waypoints to the ordered obstacle list the croquis
+ * draws. Waypoints whose categories are none of rappel / slide / jump are
+ * dropped (info points, junctions, pools on their own, …).
+ */
+export function toCroquisObstacles(
+  waypoints: CanyonWaypoint[],
+): CroquisObstacle[] {
+  const out: CroquisObstacle[] = []
+  for (const wp of waypoints) {
+    const type = resolveType(wp.categories)
+    if (!type) continue
+    out.push({
+      type,
+      title: wp.title,
+      meters: resolveMeters(wp),
+      side: wp.side ?? extractSide(wp.title),
+      severity: wp.severity ?? detectSeverity(wp.title, wp.notes),
+      notes: wp.notes,
+      lat: wp.lat,
+      lon: wp.lon,
+      ...(wp.photo ? { photo: wp.photo } : {}),
+    })
+  }
+  return out
+}

--- a/apps/web/lib/cards/croquisGlyphs.spec.ts
+++ b/apps/web/lib/cards/croquisGlyphs.spec.ts
@@ -1,0 +1,82 @@
+import {
+  glyphFor,
+  glyphRapel,
+  glyphSalto,
+  glyphTobogan,
+  river,
+  rowReturn,
+  scene,
+  waterfall,
+} from './croquisGlyphs'
+
+describe('croquisGlyphs', () => {
+  it('waterfall draws three water strokes', () => {
+    const s = waterfall(100, 50, 200)
+    expect((s.match(/<path /g) ?? []).length).toBe(3)
+  })
+
+  it('glyphRapel includes the rope, anchor and waterfall', () => {
+    const s = glyphRapel(100, 50, 180)
+    expect(s).toContain('stroke-dasharray="1 6"') // rope
+    expect(s).toContain('<circle') // anchor
+  })
+
+  it('glyphTobogan draws the chute curve', () => {
+    const s = glyphTobogan(100, 50, 180, 120)
+    expect(s).toContain('<path')
+    expect(s).toContain('C ')
+  })
+
+  it('glyphSalto draws the jump arc and pool', () => {
+    const s = glyphSalto(100, 50, 180, 120)
+    expect(s).toContain('stroke-dasharray="7 6"') // arc
+    expect(s).toContain('<ellipse') // pool
+  })
+
+  it('river is an animated flow path', () => {
+    expect(river(0, 0, 100, 100)).toContain('class="flow"')
+  })
+
+  it('rowReturn is a dashed flow sweep', () => {
+    const s = rowReturn(200, 100, 40, 300)
+    expect(s).toContain('class="flow"')
+    expect(s).toContain('stroke-dasharray="2 7"')
+  })
+
+  describe('glyphFor', () => {
+    it('stacks jump + rappel for a combo', () => {
+      const s = glyphFor('salto-rapel', 100, 50, 180, 120)
+      expect(s).toContain('stroke-dasharray="7 6"') // salto arc
+      expect(s).toContain('stroke-dasharray="1 6"') // rappel rope
+    })
+
+    it('draws a rappel', () => {
+      expect(glyphFor('rapel', 100, 50, 180, 120)).toContain(
+        'stroke-dasharray="1 6"',
+      )
+    })
+
+    it('draws a slide', () => {
+      const s = glyphFor('tobogan', 100, 50, 180, 120)
+      expect(s).not.toContain('stroke-dasharray="1 6"')
+      expect(s).toContain('<path')
+    })
+
+    it('draws a jump', () => {
+      expect(glyphFor('salto', 100, 50, 180, 120)).toContain(
+        'stroke-dasharray="7 6"',
+      )
+    })
+  })
+
+  describe('scene', () => {
+    it.each(['salto-rapel', 'rapel', 'tobogan', 'salto'] as const)(
+      'renders an illustration for %s',
+      (type) => {
+        const s = scene(type)
+        expect(s).toContain('<svg viewBox="0 0 260 128">')
+        expect(s).toContain('</svg>')
+      },
+    )
+  })
+})

--- a/apps/web/lib/cards/croquisGlyphs.ts
+++ b/apps/web/lib/cards/croquisGlyphs.ts
@@ -1,0 +1,139 @@
+import type { CroquisType } from './croquisData'
+import { AMBER, BONE, PANEL_STK, WATER, WATER_DEEP } from './theme'
+
+const isRapel = (t: CroquisType) => t === 'rapel' || t === 'salto-rapel'
+const isSalto = (t: CroquisType) => t === 'salto' || t === 'salto-rapel'
+const isTobogan = (t: CroquisType) => t === 'tobogan'
+
+/** Three stacked wavy strokes suggesting falling water between two heights. */
+export function waterfall(x: number, yTop: number, yBot: number): string {
+  const seg = (yBot - yTop) / 3
+  let s = ''
+  for (let i = -1; i <= 1; i++) {
+    const xi = x + i * 7
+    s += `<path d="M${xi} ${yTop} q6 ${seg} 0 ${seg} q-6 ${seg} 0 ${seg} q6 ${seg} 0 ${seg}" fill="none" stroke="${WATER}" stroke-width="2" stroke-opacity="${0.5 - Math.abs(i) * 0.12}" stroke-linecap="round"/>`
+  }
+  return s
+}
+
+/** Rappel: a rock lip with a waterfall, an anchor and a dashed rope line. */
+export function glyphRapel(x: number, yTop: number, yBot: number): string {
+  const w = -24
+  return (
+    `<path d="M${x} ${yTop} L${x + w} ${yTop} L${x + w - 6} ${yBot} L${x} ${yBot} Z" fill="${PANEL_STK}" stroke="#405b6c" stroke-width="1"/>` +
+    waterfall(x, yTop, yBot) +
+    `<circle cx="${x}" cy="${yTop}" r="4" fill="${AMBER}"/>` +
+    `<path d="M${x - 7} ${yTop - 2} L${x} ${yTop - 11} L${x + 7} ${yTop - 2}" fill="none" stroke="${AMBER}" stroke-width="2.4" stroke-linejoin="round"/>` +
+    `<line x1="${x}" y1="${yTop}" x2="${x}" y2="${yBot}" stroke="${AMBER}" stroke-width="2.4" stroke-dasharray="1 6" stroke-linecap="round"/>`
+  )
+}
+
+/** Slide: a smooth chute of rock with the water tracing its curve. */
+export function glyphTobogan(
+  x: number,
+  yTop: number,
+  xEnd: number,
+  yBot: number,
+): string {
+  const c1x = x + (xEnd - x) * 0.15
+  const c2x = x + (xEnd - x) * 0.6
+  const off = 15
+  const top = `M${x} ${yTop} C ${c1x} ${yTop} ${c2x} ${yBot} ${xEnd} ${yBot}`
+  const fill = `${top} L ${xEnd} ${yBot + off} C ${c2x} ${yBot + off} ${c1x} ${yTop + off} ${x} ${yTop + off} Z`
+  return (
+    `<path d="${fill}" fill="${PANEL_STK}" fill-opacity="0.55"/>` +
+    `<path d="M${x} ${yTop + off} C ${c1x} ${yTop + off} ${c2x} ${yBot + off} ${xEnd} ${yBot + off}" fill="none" stroke="#3d5b6b" stroke-width="2"/>` +
+    `<path d="${top}" fill="none" stroke="${WATER}" stroke-width="3" stroke-linecap="round"/>`
+  )
+}
+
+/** Jump: a dashed leap arc from a take-off ledge into a rippling pool. */
+export function glyphSalto(
+  x: number,
+  yTop: number,
+  xEnd: number,
+  yBot: number,
+): string {
+  const midx = (x + xEnd) / 2
+  const apex = yTop - 28
+  return (
+    `<path d="M${x} ${yTop} Q ${midx} ${apex} ${xEnd} ${yBot - 6}" fill="none" stroke="${BONE}" stroke-width="2.2" stroke-dasharray="7 6" stroke-opacity="0.85"/>` +
+    `<path d="M${x - 4} ${yTop} l8 0" stroke="${PANEL_STK}" stroke-width="6" stroke-linecap="round"/>` +
+    `<ellipse cx="${xEnd}" cy="${yBot + 6}" rx="30" ry="11" fill="${WATER_DEEP}"/>` +
+    `<ellipse cx="${xEnd}" cy="${yBot + 6}" rx="30" ry="11" fill="none" stroke="${WATER}" stroke-width="1.5" opacity="0.8"/>` +
+    `<path d="M${xEnd - 14} ${yBot + 4} q7 5 14 0 M${xEnd - 9} ${yBot + 9} q5 4 10 0" stroke="${WATER}" stroke-width="1.3" fill="none" opacity="0.7"/>`
+  )
+}
+
+/** The river course between two points: a smooth S-curve of flowing water. */
+export function river(x1: number, y1: number, x2: number, y2: number): string {
+  const mx = (x1 + x2) / 2
+  return `<path class="flow" d="M${x1} ${y1} C ${mx} ${y1} ${mx} ${y2} ${x2} ${y2}" fill="none" stroke="${WATER}" stroke-width="3.5" stroke-linecap="round" opacity="0.9"/>`
+}
+
+/**
+ * Carriage return: the river dropping from the right end of one row back to
+ * the left of the next, a fainter dashed sweep so it reads as a continuation.
+ */
+export function rowReturn(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): string {
+  const my = (y1 + y2) / 2
+  return `<path class="flow" d="M${x1} ${y1} C ${x1 + 40} ${my} ${x2 - 40} ${my} ${x2} ${y2}" fill="none" stroke="${WATER}" stroke-width="3" stroke-linecap="round" opacity="0.7" stroke-dasharray="2 7"/>`
+}
+
+/** The glyph(s) for an obstacle at its position (combos stack jump + rappel). */
+export function glyphFor(
+  type: CroquisType,
+  x: number,
+  yTop: number,
+  endX: number,
+  yBot: number,
+): string {
+  if (isRapel(type) && isSalto(type)) {
+    return glyphSalto(x, yTop, endX, yBot) + glyphRapel(x, yTop, yBot)
+  }
+  if (isRapel(type)) return glyphRapel(x, yTop, yBot)
+  if (isTobogan(type)) return glyphTobogan(x, yTop, endX, yBot)
+  return glyphSalto(x, yTop, endX, yBot)
+}
+
+/** A larger illustration of the obstacle type, drawn for the hover popover. */
+export function scene(type: CroquisType): string {
+  const sky = `<rect width="260" height="128" fill="#0a1218"/><path d="M0 96 Q40 78 80 92 T160 88 T260 96 L260 128 L0 128Z" fill="#132330"/>`
+  if (isRapel(type) && isSalto(type)) {
+    return `<svg viewBox="0 0 260 128">${sky}
+      <path d="M150 8 L210 8 L210 128 L150 128 Z" fill="${PANEL_STK}"/>
+      <path d="M60 40 Q120 4 148 118" stroke="${BONE}" stroke-width="2.2" stroke-dasharray="7 6" fill="none"/>
+      <line x1="150" y1="12" x2="150" y2="104" stroke="${AMBER}" stroke-width="2.5" stroke-dasharray="2 6"/>
+      <circle cx="150" cy="12" r="4" fill="${AMBER}"/>
+      <ellipse cx="150" cy="118" rx="30" ry="8" fill="${WATER_DEEP}"/></svg>`
+  }
+  if (isRapel(type)) {
+    return `<svg viewBox="0 0 260 128">${sky}
+      <path d="M150 8 L210 8 L210 128 L150 128 Z" fill="${PANEL_STK}"/>
+      <path d="M158 8 q6 30 0 60 q-6 30 0 60" stroke="${WATER}" stroke-width="3" fill="none" opacity="0.7"/>
+      <path d="M168 8 q6 30 0 60 q-6 30 0 60" stroke="${WATER}" stroke-width="3" fill="none" opacity="0.4"/>
+      <line x1="150" y1="12" x2="150" y2="104" stroke="${AMBER}" stroke-width="2.5" stroke-dasharray="2 6"/>
+      <circle cx="150" cy="12" r="4" fill="${AMBER}"/>
+      <ellipse cx="150" cy="118" rx="30" ry="8" fill="${WATER_DEEP}"/>
+      <circle cx="146" cy="80" r="6" fill="${BONE}"/><path d="M146 86 l0 14 M146 90 l-8 6 M146 90 l8 6 M146 100 l-6 12 M146 100 l6 12" stroke="${BONE}" stroke-width="2" fill="none"/></svg>`
+  }
+  if (isTobogan(type)) {
+    return `<svg viewBox="0 0 260 128">${sky}
+      <path d="M20 30 C 90 30 120 96 240 100 L240 116 C120 112 90 46 20 46 Z" fill="${PANEL_STK}" fill-opacity="0.7"/>
+      <path d="M20 30 C 90 30 120 96 240 100" stroke="${WATER}" stroke-width="4" fill="none"/>
+      <ellipse cx="236" cy="112" rx="22" ry="7" fill="${WATER_DEEP}"/>
+      <circle cx="120" cy="60" r="6" fill="${BONE}"/><path d="M120 66 l6 12 M120 70 l-10 2 M126 78 l8 4" stroke="${BONE}" stroke-width="2" fill="none"/></svg>`
+  }
+  return `<svg viewBox="0 0 260 128">${sky}
+      <path d="M20 40 l40 0 l0 88 l-40 0Z" fill="${PANEL_STK}"/>
+      <path d="M60 40 Q140 -6 210 108" stroke="${BONE}" stroke-width="2.4" stroke-dasharray="7 6" fill="none"/>
+      <ellipse cx="210" cy="116" rx="34" ry="10" fill="${WATER_DEEP}"/>
+      <ellipse cx="210" cy="116" rx="34" ry="10" fill="none" stroke="${WATER}"/>
+      <path d="M196 114 q14 6 28 0 M202 120 q8 4 16 0" stroke="${WATER}" fill="none" opacity="0.7"/>
+      <g transform="translate(132,34) rotate(20)"><circle cx="0" cy="0" r="6" fill="${BONE}"/><path d="M0 6 l0 14 M0 9 l-9 4 M0 9 l9 4 M0 20 l-7 10 M0 20 l7 10" stroke="${BONE}" stroke-width="2" fill="none"/></g></svg>`
+}

--- a/apps/web/lib/cards/croquisLayout.spec.ts
+++ b/apps/web/lib/cards/croquisLayout.spec.ts
@@ -1,0 +1,115 @@
+import type { CroquisObstacle, CroquisType } from './croquisData'
+import { CROQUIS_WIDTH, SINGLE_MAX, layoutCroquis } from './croquisLayout'
+
+function ob(type: CroquisType, meters: number | null = 5): CroquisObstacle {
+  return {
+    type,
+    title: `${type} ${meters}`,
+    meters,
+    side: null,
+    severity: 'easy',
+    notes: [],
+  }
+}
+
+function many(n: number, type: CroquisType = 'salto'): CroquisObstacle[] {
+  return Array.from({ length: n }, () => ob(type))
+}
+
+describe('layoutCroquis', () => {
+  it('returns an empty single layout for no obstacles', () => {
+    const l = layoutCroquis([])
+    expect(l.mode).toBe('single')
+    expect(l.nodes).toHaveLength(0)
+    expect(l.segments).toHaveLength(0)
+    expect(l.height).toBe(200)
+    expect(l.width).toBe(CROQUIS_WIDTH)
+  })
+
+  describe('single mode', () => {
+    it('stays single up to the threshold', () => {
+      const l = layoutCroquis(many(SINGLE_MAX))
+      expect(l.mode).toBe('single')
+      expect(l.nodes).toHaveLength(SINGLE_MAX)
+      expect(l.nodes.every((n) => n.row === null)).toBe(true)
+    })
+
+    it('connects with rivers only (no row returns)', () => {
+      const l = layoutCroquis(many(3))
+      expect(l.segments.every((s) => s.kind === 'river')).toBe(true)
+      // access sweep + 2 inter-node + exit tail
+      expect(l.segments).toHaveLength(4)
+    })
+
+    it('exits a rappel from its foot and a jump from its pool', () => {
+      const l = layoutCroquis([ob('rapel'), ob('salto')])
+      expect(l.nodes[0].exitX).toBe(l.nodes[0].x)
+      expect(l.nodes[1].exitX).toBe(l.nodes[1].endX)
+    })
+
+    it('normalises tall descents to fit the band', () => {
+      const l = layoutCroquis(
+        many(SINGLE_MAX, 'rapel').map(() => ob('rapel', 200)),
+      )
+      const maxY = Math.max(...l.nodes.map((n) => n.yBot))
+      expect(maxY).toBeLessThanOrEqual(391)
+    })
+
+    it('does not scale up a short descent', () => {
+      const l = layoutCroquis([ob('salto', 1), ob('salto', 1)])
+      // first node keeps the raw TOP baseline (no upscaling)
+      expect(l.nodes[0].yTop).toBeCloseTo(90)
+    })
+
+    it('treats null metres as the minimum drop', () => {
+      const l = layoutCroquis([ob('salto', null)])
+      expect(l.nodes[0].yBot - l.nodes[0].yTop).toBeCloseTo(46)
+    })
+
+    it('produces a hit box around each gesture', () => {
+      const [n] = layoutCroquis([ob('salto', 5)]).nodes
+      expect(n.box.w).toBe(n.endX - n.x + 80)
+      expect(n.box.x).toBe(n.x - 40)
+    })
+  })
+
+  describe('serpentine mode', () => {
+    it('switches above the threshold', () => {
+      const l = layoutCroquis(many(SINGLE_MAX + 1))
+      expect(l.mode).toBe('serpentine')
+    })
+
+    it('fills the container width and assigns rows', () => {
+      const l = layoutCroquis(many(9), 1180)
+      expect(l.width).toBe(1180)
+      // perRow = floor((1180-160)/185) = 5 → index 5 starts row 1
+      expect(l.nodes[4].row).toBe(0)
+      expect(l.nodes[5].row).toBe(1)
+    })
+
+    it('drops to the next row with a return sweep', () => {
+      const l = layoutCroquis(many(9), 1180)
+      expect(l.segments.some((s) => s.kind === 'return')).toBe(true)
+    })
+
+    it('keeps at least three obstacles per row on a narrow width', () => {
+      const l = layoutCroquis(many(9), 100)
+      expect(l.width).toBe(640)
+      // perRow clamped to 3 → index 3 starts row 1
+      expect(l.nodes[3].row).toBe(1)
+    })
+
+    it('treats null metres as the minimum drop in a row', () => {
+      const obstacles = many(9)
+      obstacles[0] = ob('salto', null)
+      const l = layoutCroquis(obstacles, 1180)
+      expect(l.nodes[0].yBot - l.nodes[0].yTop).toBeCloseTo(30)
+    })
+
+    it('assigns rows across a long descent', () => {
+      const l = layoutCroquis(many(12, 'rapel'), 1180)
+      expect(l.nodes[0].row).toBe(0)
+      expect(l.nodes[11].row).toBe(Math.floor(11 / 5))
+    })
+  })
+})

--- a/apps/web/lib/cards/croquisLayout.ts
+++ b/apps/web/lib/cards/croquisLayout.ts
@@ -1,0 +1,234 @@
+import type { CroquisObstacle } from './croquisData'
+
+/** A positioned obstacle within the croquis. */
+export interface CroquisNode {
+  obstacle: CroquisObstacle
+  index: number
+  /** Entry x (the obstacle's lip / take-off). */
+  x: number
+  /** Top (lip) and bottom (pool / landing) y of the gesture. */
+  yTop: number
+  yBot: number
+  /** Downstream end of the gesture (pool for jumps/slides). */
+  endX: number
+  /** Where the river exits — the foot for a vertical rappel, else endX. */
+  exitX: number
+  /** Row index in serpentine mode, null in single-line mode. */
+  row: number | null
+  /** Hover / hit region around the gesture. */
+  box: { x: number; y: number; w: number; h: number }
+}
+
+/** A stretch of river between two points. */
+export interface CroquisSegment {
+  kind: 'river' | 'return'
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+}
+
+/** A fully laid-out croquis, ready to render either statically or live. */
+export interface CroquisLayout {
+  mode: 'single' | 'serpentine'
+  nodes: CroquisNode[]
+  segments: CroquisSegment[]
+  access: { x: number; y: number }
+  exit: { x: number; y: number }
+  width: number
+  height: number
+}
+
+/** Above this obstacle count the river serpentines into rows. */
+export const SINGLE_MAX = 8
+/** Default drawing width used for the PNG export and the fallback preview. */
+export const CROQUIS_WIDTH = 1180
+
+const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v))
+
+interface Raw {
+  obstacle: CroquisObstacle
+  index: number
+  x: number
+  yTop: number
+  yBot: number
+  row: number | null
+}
+
+/** Finish a raw placement into a node (endX / exitX / hit box). */
+function toNode(raw: Raw, run: number): CroquisNode {
+  const endX = raw.x + run
+  // A pure rappel is a vertical drop at x, so the river exits from its foot;
+  // jumps and slides (and combos) exit from their downstream pool at endX.
+  const exitX = raw.obstacle.type === 'rapel' ? raw.x : endX
+  return {
+    obstacle: raw.obstacle,
+    index: raw.index,
+    x: raw.x,
+    yTop: raw.yTop,
+    yBot: raw.yBot,
+    endX,
+    exitX,
+    row: raw.row,
+    box: {
+      x: raw.x - 40,
+      y: raw.yTop - 44,
+      w: endX - raw.x + 80,
+      h: raw.yBot - raw.yTop + 92,
+    },
+  }
+}
+
+/** Connectors (access sweep, river between nodes, row returns, exit tail). */
+function buildSegments(nodes: CroquisNode[]): {
+  segments: CroquisSegment[]
+  access: { x: number; y: number }
+  exit: { x: number; y: number }
+} {
+  const first = nodes[0]
+  const segments: CroquisSegment[] = [
+    {
+      kind: 'river',
+      x1: first.x - 70,
+      y1: first.yTop,
+      x2: first.x,
+      y2: first.yTop,
+    },
+  ]
+  for (let i = 1; i < nodes.length; i++) {
+    const prev = nodes[i - 1]
+    const node = nodes[i]
+    const wrap = prev.row !== null && prev.row !== node.row
+    segments.push({
+      kind: wrap ? 'return' : 'river',
+      x1: prev.exitX,
+      y1: prev.yBot,
+      x2: node.x,
+      y2: node.yTop,
+    })
+  }
+  const last = nodes[nodes.length - 1]
+  const exit = { x: last.exitX + 96, y: last.yBot + 16 }
+  segments.push({
+    kind: 'river',
+    x1: last.exitX,
+    y1: last.yBot,
+    x2: exit.x,
+    y2: exit.y,
+  })
+  return { segments, access: { x: first.x, y: first.yTop }, exit }
+}
+
+/** Single flowing line: cumulative descent, normalised to a fixed band height. */
+function layoutSingle(obstacles: CroquisObstacle[]): CroquisLayout {
+  const STEP = 240
+  const PAD = 120
+  const TOP = 90
+  const H = 460
+  const run = STEP * 0.42
+  const dropPx = (m: number) => clamp(46 + Math.sqrt(m) * 26, 46, 210)
+
+  let y = TOP
+  const raws: Raw[] = obstacles.map((obstacle, index) => {
+    const x = PAD + index * STEP
+    const drop = dropPx(obstacle.meters ?? 0)
+    const yTop = y
+    const yBot = y + drop
+    y = yBot
+    return { obstacle, index, x, yTop, yBot, row: null }
+  })
+
+  const maxY = Math.max(...raws.map((r) => r.yBot))
+  const sc = maxY > H - 70 ? (H - 70 - TOP) / (maxY - TOP) : 1
+  raws.forEach((r) => {
+    r.yTop = TOP + (r.yTop - TOP) * sc
+    r.yBot = TOP + (r.yBot - TOP) * sc
+  })
+
+  const nodes = raws.map((r) => toNode(r, run))
+  const { segments, access, exit } = buildSegments(nodes)
+  return {
+    mode: 'single',
+    nodes,
+    segments,
+    access,
+    exit,
+    width: PAD * 2 + (obstacles.length - 1) * STEP + 200,
+    height: H,
+  }
+}
+
+/** Serpentine: rows fill the width L→R, the river keeps descending within each. */
+function layoutSerpentine(
+  obstacles: CroquisObstacle[],
+  containerWidth: number,
+): CroquisLayout {
+  const STEP = 185
+  const PAD = 80
+  const TOP = 70
+  const DESC = 18
+  const ROW_GAP = 34
+  const LABEL_H = 46
+  const run = STEP * 0.4
+  const targetW = Math.max(640, containerWidth)
+  const perRow = Math.max(3, Math.floor((targetW - PAD * 2) / STEP))
+  const dropPx = (m: number) => clamp(30 + Math.sqrt(m) * 13, 30, 92)
+  const nRows = Math.ceil(obstacles.length / perRow)
+
+  const nodes: CroquisNode[] = []
+  let cursorY = TOP
+  for (let r = 0; r < nRows; r++) {
+    let y = cursorY + 20
+    let rowBottom = y
+    for (let c = 0; c < perRow; c++) {
+      const index = r * perRow + c
+      if (index >= obstacles.length) break
+      const obstacle = obstacles[index]
+      const x = PAD + c * STEP
+      const drop = dropPx(obstacle.meters ?? 0)
+      const yTop = y
+      const yBot = y + drop
+      nodes.push(toNode({ obstacle, index, x, yTop, yBot, row: r }, run))
+      y = yBot + DESC
+      rowBottom = yBot
+    }
+    cursorY = rowBottom + LABEL_H + ROW_GAP
+  }
+
+  const { segments, access, exit } = buildSegments(nodes)
+  return {
+    mode: 'serpentine',
+    nodes,
+    segments,
+    access,
+    exit,
+    width: targetW,
+    height: cursorY + 10,
+  }
+}
+
+/**
+ * Lay out obstacles into a croquis. Few obstacles flow along a single
+ * descending line; many serpentine into rows that fill `containerWidth` and
+ * grow downward. Returns geometry only — rendering (static SVG or the live
+ * component) is layered on top.
+ */
+export function layoutCroquis(
+  obstacles: CroquisObstacle[],
+  containerWidth: number = CROQUIS_WIDTH,
+): CroquisLayout {
+  if (obstacles.length === 0) {
+    return {
+      mode: 'single',
+      nodes: [],
+      segments: [],
+      access: { x: 0, y: 0 },
+      exit: { x: 0, y: 0 },
+      width: Math.max(640, containerWidth),
+      height: 200,
+    }
+  }
+  return obstacles.length <= SINGLE_MAX
+    ? layoutSingle(obstacles)
+    : layoutSerpentine(obstacles, containerWidth)
+}

--- a/apps/web/lib/cards/index.ts
+++ b/apps/web/lib/cards/index.ts
@@ -27,15 +27,33 @@ export type {
 } from './canyonWaypoints'
 export { canyonWaypointCard } from './canyonWaypointCard'
 export type { CanyonWaypointCardData } from './canyonWaypointCard'
+export { toCroquisObstacles, isDrawableWaypoint } from './croquisData'
+export type { CroquisObstacle, CroquisType } from './croquisData'
+export { layoutCroquis, SINGLE_MAX, CROQUIS_WIDTH } from './croquisLayout'
+export type {
+  CroquisLayout,
+  CroquisNode,
+  CroquisSegment,
+} from './croquisLayout'
+export { scene } from './croquisGlyphs'
+export {
+  croquisCard,
+  croquisBackground,
+  croquisConnectors,
+  croquisNodeContent,
+} from './croquisCard'
 export { svgToPng } from './svgToPng'
 export { zipStore } from './zip'
 export type { ZipFile } from './zip'
 export {
   STRINGS,
+  SEV_COLORS,
+  AMBER,
   FLOW_LEVEL_KEYS,
   FLOW_RAPPEL_KEYS,
   PHENOMENA_KEYS,
 } from './theme'
+export { FONT_STYLE } from './fonts'
 export type {
   CardSpec,
   CanyoningCardData,

--- a/apps/web/lib/cards/theme.ts
+++ b/apps/web/lib/cards/theme.ts
@@ -8,6 +8,9 @@ export const AMBER = '#F4B83C'
 export const AMBER_DK = '#C98A1E'
 export const TRACK_BG = '#24384A'
 export const CONTOUR = '#2E4654'
+/** River-course colours for the croquis (flowing water + pool depth). */
+export const WATER = '#57BBCE'
+export const WATER_DEEP = '#2C7E90'
 
 /** Traffic-light colours for the waypoint severity indicator. */
 export const SEV_COLORS: Record<'easy' | 'caution' | 'danger', string> = {
@@ -96,6 +99,8 @@ export const STRINGS = {
     sev_easy: 'FÁCIL',
     sev_caution: 'ATENCIÓN',
     sev_danger: 'PELIGRO',
+    croquis_access: 'ACCESO',
+    croquis_exit: 'SALIDA',
     default_title: 'Resumen de ruta',
     flow_levels: {
       dry: 'Seco / residual',
@@ -188,6 +193,8 @@ export const STRINGS = {
     sev_easy: 'EASY',
     sev_caution: 'CAUTION',
     sev_danger: 'DANGER',
+    croquis_access: 'ACCESS',
+    croquis_exit: 'EXIT',
     default_title: 'Route summary',
     flow_levels: {
       dry: 'Dry / residual',

--- a/apps/web/lib/mdx/components.tsx
+++ b/apps/web/lib/mdx/components.tsx
@@ -2,6 +2,7 @@ import { Callout } from '@sdlgr/callout'
 import { CodeBlock } from '@sdlgr/code-block'
 
 import { MdxTable } from '@web/components/PostContent/MdxTable'
+import { PostContentCroquis } from '@web/components/PostContent/PostContentCroquis'
 import { PostContentEmbed } from '@web/components/PostContent/PostContentEmbed'
 import { PostContentImage } from '@web/components/PostContent/PostContentImage'
 import { PostContentSlideshow } from '@web/components/PostContent/PostContentSlideshow'
@@ -16,6 +17,7 @@ export function createMdxComponents(labels: MdxComponentLabels) {
     Callout,
     Embed: PostContentEmbed,
     Slideshow: PostContentSlideshow,
+    Croquis: PostContentCroquis,
     img: PostContentImage,
     h1: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
       <h2 {...props}>{children}</h2>

--- a/apps/web/lib/mdx/remarkEmbeds.spec.ts
+++ b/apps/web/lib/mdx/remarkEmbeds.spec.ts
@@ -717,4 +717,34 @@ describe('remarkEmbeds', () => {
       })
     })
   })
+
+  describe('croquis blocks', () => {
+    it('transforms a croquis block into a Croquis element with obstacles JSON', () => {
+      const [result] = runPlugin([
+        {
+          type: 'code',
+          lang: 'croquis',
+          value: 'salto: Jump 2m\n! side=right; img=https://img/x.jpg',
+        },
+      ])
+      expect(result.type).toBe('mdxJsxFlowElement')
+      expect(result.name).toBe('Croquis')
+      const attr = result.attributes?.find((a) => a.name === 'obstacles')
+      const obstacles = JSON.parse(attr?.value ?? '[]')
+      expect(obstacles).toHaveLength(1)
+      expect(obstacles[0]).toMatchObject({
+        type: 'salto',
+        side: 'right',
+        photo: 'https://img/x.jpg',
+      })
+    })
+
+    it('drops non-obstacle waypoints and handles an empty body', () => {
+      const [result] = runPlugin([
+        { type: 'code', lang: 'croquis', value: undefined },
+      ])
+      const attr = result.attributes?.find((a) => a.name === 'obstacles')
+      expect(attr?.value).toBe('[]')
+    })
+  })
 })

--- a/apps/web/lib/mdx/remarkEmbeds.ts
+++ b/apps/web/lib/mdx/remarkEmbeds.ts
@@ -1,3 +1,5 @@
+import { parseCanyonWaypointsText, toCroquisObstacles } from '@web/lib/cards'
+
 const EMBED_LANGS = [
   'youtube',
   'youtube-360',
@@ -59,6 +61,24 @@ export function remarkEmbeds() {
               type: 'mdxJsxAttribute',
               name: 'slides',
               value: JSON.stringify(slides),
+            },
+          ],
+          children: [],
+        }
+      }
+
+      if (n.lang === 'croquis') {
+        const obstacles = toCroquisObstacles(
+          parseCanyonWaypointsText(n.value ?? ''),
+        )
+        return {
+          type: 'mdxJsxFlowElement',
+          name: 'Croquis',
+          attributes: [
+            {
+              type: 'mdxJsxAttribute',
+              name: 'obstacles',
+              value: JSON.stringify(obstacles),
             },
           ],
           children: [],


### PR DESCRIPTION
Cards admin: new 'Croquis' tab draws a river-course schematic from canyon waypoints (jump/rappel/slide + combos), adaptive single-line vs serpentine layout, hover popover (photo or drawn scene), PNG export/upload.

Post editor: 'Insert Croquis' modal (waypoint text or GPX parse, per-waypoint image via the shared GPX-style picker, live preview) inserts a ```croquis fence; remark transform renders the interactive read-only map in the post, localised, with touch tap + hover-intent popover.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Mandatory gif:

![](https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif)
